### PR TITLE
Replace questions with structured reviews from quesgen API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Flutter movie journal application that allows users to search for movies, view movie details, and create journal entries with emotions, thoughts, and AI-generated questions about watched movies. The app integrates with The Movie Database (TMDB) API and uses Firebase for authentication and data storage.
+This is a Flutter movie journal application that allows users to search for movies, view movie details, and create journal entries with emotions, thoughts, and AI-curated reviews about watched movies. The app integrates with The Movie Database (TMDB) API and uses Firebase for authentication and data storage.
 
 ## Development Commands
 
@@ -60,7 +60,7 @@ The app follows a feature-based architecture where each feature is self-containe
 - **journal/** - Core journaling features with full workflow from movie selection to saving
   - `controllers/` - JournalState (single journal), JournalsState (list of journals)
   - `screens/` - Journaling (main editor), JournalContent (view saved journal), MoviePreview, ThoughtsEditor, CaptionEditor
-  - `widgets/` - EmotionsSelectorButton, EmotionsSelectorBottomSheet, ScenesSelector, ScenesSelectSheet, SceneCard, QuestionsBottomSheet, ThoughtsEditor, PosterPreviewModal, AiReferencesAccordion, JournalContentMoreMenu
+  - `widgets/` - EmotionsSelectorButton, EmotionsSelectorBottomSheet, ScenesSelector, ScenesSelectSheet, SceneCard, ReviewsBottomSheet, ThoughtsEditor, PosterPreviewModal, AiReferencesAccordion, JournalContentMoreMenu
 
 - **movie/** - Movie data management with repository pattern
   - `controllers/` - MovieDetailController, MovieImagesController, SearchMovieController
@@ -80,10 +80,11 @@ The app follows a feature-based architecture where each feature is self-containe
     - **Soothing** (low energy, positive): Heartwarming, Touched, Peaceful, Therapeutic, Nostalgic, Cozy
     - **Quiet** (low energy, negative): Melancholic, Confused, Profound, Bittersweet, Powerless, Lonely
 
-- **quesgen/** - AI question generation service for movie reflection prompts
-  - `controller.dart` - Question generation logic
+- **quesgen/** - AI review fetching service for movie reviews from external sources
+  - `review.dart` - Review data model with `text` and `source` fields (sources: "letterboxd", "reddit")
+  - `controller.dart` - Review generation logic (QuesgenController, QuesgenState)
   - `provider.dart` - Riverpod provider
-  - `api.dart` - API integration for AI-generated questions
+  - `api.dart` - API integration (GET `/generate/{movieId}`) returning `{ reviews: [{ text, source }] }`
 
 - **login/** - Authentication screens and user creation flows
   - `screens/` - LoginScreen, CreateUserScreen
@@ -99,7 +100,7 @@ The app follows a feature-based architecture where each feature is self-containe
 **lib/core/**
 - `network/` - Dio HTTP clients for external APIs
   - `tmdb_dio_client.dart` - The Movie Database API client
-  - `quesgen_dio_client.dart` - AI question generation API client
+  - `quesgen_dio_client.dart` - AI review generation API client
 - `utils/` - Shared utility functions
   - `color_utils.dart` - Color manipulation utilities
 
@@ -132,12 +133,12 @@ Uses **Riverpod** for state management:
 2. **Journal Creation**:
    - Select movie → MoviePreview → Start journaling → Journaling screen
    - Select emotions (EmotionsSelectorBottomSheet) → Select scenes (ScenesSelectSheet) → Write thoughts (ThoughtsEditor)
-   - Optionally generate AI questions (QuestionsBottomSheet via `quesgen_dio_client.dart`)
+   - Optionally fetch AI-curated reviews (ReviewsBottomSheet via `quesgen_dio_client.dart`)
    - Add caption (CaptionEditor) → Save to Firestore (via `FirestoreManager`) with userId
 
 3. **Journal Viewing**:
    - HomeScreen displays JournalsList → Fetch from Firestore by userId
-   - Select journal → JournalContent screen → View emotions, thoughts, scenes, questions
+   - Select journal → JournalContent screen → View emotions, thoughts, scenes, reviews
 
 4. **Authentication**:
    - LoginScreen → Apple/Google Sign-In → Firebase Auth → Store user session
@@ -171,7 +172,7 @@ Uses **Riverpod** for state management:
 
 The app requires a `.env` file in the root directory with:
 - TMDB API key
-- Question generation API endpoint and key
+- Review generation API endpoint and key
 - Other environment-specific configuration
 
 Firebase configuration is in `lib/firebase_options.dart` (auto-generated).
@@ -280,9 +281,9 @@ feature_name/
 - **Key widgets**:
   - `emotions_selector_button.dart` & `emotions_selector_bottom_sheet.dart` - Emotion selection UI
   - `scenes_selector.dart` & `scenes_select_sheet.dart` - Scene selection from movie images
-  - `questions_bottom_sheet.dart` - AI-generated questions display
+  - `reviews_bottom_sheet.dart` - AI-curated reviews display with source badges
   - `poster_preview_modal.dart` - Full-size poster preview modal
-  - `ai_references_accordion.dart` - Expandable AI references section
+  - `ai_references_accordion.dart` - Expandable AI references/reviews section
   - `journal_content_more_menu.dart` - More options menu for saved journals
 - Save to Firestore via `FirestoreManager.addJournalToCollection(userId, journal)`
 

--- a/lib/features/journal/controllers/journal.dart
+++ b/lib/features/journal/controllers/journal.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jiffy/jiffy.dart';
 import 'package:movie_journal/features/emotion/emotion.dart';
 import 'package:movie_journal/features/journal/controllers/journals.dart';
+import 'package:movie_journal/features/quesgen/review.dart';
 import 'package:movie_journal/firestore_manager.dart';
 import 'package:uuid/uuid.dart';
 
@@ -50,7 +51,7 @@ class JournalState {
   String moviePoster = '';
   List<Emotion> emotions = [];
   List<SceneItem> selectedScenes = [];
-  List<String> selectedRefs = [];
+  List<Review> selectedRefs = [];
   String thoughts = '';
   late Jiffy createdAt;
   late Jiffy updatedAt;
@@ -62,12 +63,13 @@ class JournalState {
     this.moviePoster = '',
     this.emotions = const [],
     this.selectedScenes = const [],
-    this.selectedRefs = const [],
+    List<Review>? selectedRefs,
     this.thoughts = '',
     Jiffy? createdAt,
     Jiffy? updatedAt,
   }) {
     this.id = id ?? Uuid().v4();
+    this.selectedRefs = selectedRefs ?? [];
     this.createdAt = createdAt ?? Jiffy.now();
     this.updatedAt = updatedAt ?? this.createdAt;
   }
@@ -79,7 +81,7 @@ class JournalState {
     String? moviePoster,
     List<Emotion>? emotions,
     List<SceneItem>? selectedScenes,
-    List<String>? selectedRefs,
+    List<Review>? selectedRefs,
     String? thoughts,
     Jiffy? createdAt,
     Jiffy? updatedAt,
@@ -105,7 +107,7 @@ class JournalState {
       'moviePoster': moviePoster,
       'emotions': emotions.map((e) => e.id).toList(),
       'selectedScenes': selectedScenes.map((scene) => scene.toMap()).toList(),
-      'selectedRefs': selectedRefs,
+      'selectedRefs': selectedRefs.map((r) => r.toMap()).toList(),
       'thoughts': thoughts,
       'createdAt': createdAt.toString(),
       'updatedAt': updatedAt.toString(),
@@ -120,7 +122,7 @@ class JournalState {
       'moviePoster': moviePoster,
       'emotions': emotions.map((e) => e.id).toList(),
       'selectedScenes': selectedScenes.map((scene) => scene.toMap()).toList(),
-      'selectedRefs': selectedRefs,
+      'selectedRefs': selectedRefs.map((r) => r.toMap()).toList(),
       'thoughts': thoughts,
       'createdAt': createdAt.toString(),
       'updatedAt': updatedAt.toString(),
@@ -130,6 +132,22 @@ class JournalState {
   static JournalState fromJson(String json) {
     // Decode a given json string and return a JournalState object
     final map = jsonDecode(json);
+
+    // Parse selectedRefs with backward compatibility
+    List<Review> parseSelectedRefs(dynamic refsData) {
+      if (refsData == null) return [];
+
+      final refsList = refsData as List<dynamic>;
+      return refsList.map((item) {
+        if (item is String) {
+          // Backward compatibility: old format was just strings
+          return Review.fromString(item);
+        } else if (item is Map<String, dynamic>) {
+          return Review.fromMap(item);
+        }
+        return Review.fromString(item.toString());
+      }).toList();
+    }
 
     // Parse selectedScenes with backward compatibility
     List<SceneItem> parseSelectedScenes(dynamic scenesData) {
@@ -165,7 +183,7 @@ class JournalState {
             return emotionEntry.value;
           }).toList(),
       selectedScenes: parseSelectedScenes(map['selectedScenes']),
-      selectedRefs: List<String>.from(map['selectedRefs'] ?? []),
+      selectedRefs: parseSelectedRefs(map['selectedRefs']),
       thoughts: map['thoughts'] ?? '',
       createdAt:
           map['createdAt'] != null
@@ -219,8 +237,8 @@ class JournalController extends Notifier<JournalState> {
     return this;
   }
 
-  JournalController setselectedRefs(List<String> questions) {
-    state = state.copyWith(selectedRefs: questions);
+  JournalController setSelectedReviews(List<Review> reviews) {
+    state = state.copyWith(selectedRefs: reviews);
     return this;
   }
 
@@ -236,14 +254,14 @@ class JournalController extends Notifier<JournalState> {
     return this;
   }
 
-  JournalController addSelectedQuestion(String question) {
-    state = state.copyWith(selectedRefs: [...state.selectedRefs, question]);
+  JournalController addSelectedReview(Review review) {
+    state = state.copyWith(selectedRefs: [...state.selectedRefs, review]);
     return this;
   }
 
-  JournalController removeSelectedQuestion(String question) {
+  JournalController removeSelectedReview(Review review) {
     state = state.copyWith(
-      selectedRefs: state.selectedRefs.where((e) => e != question).toList(),
+      selectedRefs: state.selectedRefs.where((e) => e != review).toList(),
     );
     return this;
   }

--- a/lib/features/journal/screens/thoughts.dart
+++ b/lib/features/journal/screens/thoughts.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:movie_journal/features/journal/controllers/journal.dart';
 import 'package:movie_journal/features/journal/widgets/ai_references_accordion.dart';
-import 'package:movie_journal/features/journal/widgets/questions_bottom_sheet.dart';
+import 'package:movie_journal/features/journal/widgets/reviews_bottom_sheet.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
 import 'package:movie_journal/features/quesgen/provider.dart';
 import 'package:movie_journal/shared_widgets/action_text_button.dart';
@@ -103,10 +103,10 @@ class _ThoughtsScreenState extends ConsumerState<ThoughtsScreen> {
     final movieAsync = ref.read(movieDetailControllerProvider);
     final movie = movieAsync.hasValue ? movieAsync.value : null;
     final quesgenState = ref.read(quesgenControllerProvider);
-    if (movie != null && quesgenState.questions.isEmpty) {
+    if (movie != null && quesgenState.reviews.isEmpty) {
       ref
           .read(quesgenControllerProvider.notifier)
-          .generateQuestions(movieId: movie.id);
+          .generateReviews(movieId: movie.id);
     }
     if (context.mounted) {
       showModalBottomSheet(
@@ -114,7 +114,7 @@ class _ThoughtsScreenState extends ConsumerState<ThoughtsScreen> {
         isScrollControlled: true,
         context: context,
         backgroundColor: Color(0xFF171717),
-        builder: (context) => Wrap(children: [QuestionsBottomSheet()]),
+        builder: (context) => Wrap(children: [ReviewsBottomSheet()]),
       );
     }
   }
@@ -201,7 +201,7 @@ class _ThoughtsScreenState extends ConsumerState<ThoughtsScreen> {
                     onRemove: (index) {
                       ref
                           .read(journalControllerProvider.notifier)
-                          .removeSelectedQuestion(selectedReferences[index]);
+                          .removeSelectedReview(selectedReferences[index]);
                     },
                   )
                   : SizedBox.shrink(),

--- a/lib/features/journal/widgets/ai_references_accordion.dart
+++ b/lib/features/journal/widgets/ai_references_accordion.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:movie_journal/features/quesgen/review.dart';
 
 class AiReferencesAccordion extends StatefulWidget {
   const AiReferencesAccordion({
@@ -9,7 +10,7 @@ class AiReferencesAccordion extends StatefulWidget {
     this.defaultExpanded = false,
   });
 
-  final List<String> references;
+  final List<Review> references;
   final Function(int index) onRemove;
   final bool defaultExpanded;
   @override
@@ -104,9 +105,9 @@ class _AiReferencesAccordionState extends State<AiReferencesAccordion>
                 children:
                     widget.references.asMap().entries.map((entry) {
                       final index = entry.key;
-                      final reference = entry.value;
+                      final review = entry.value;
                       return _ReferenceCard(
-                        reference: reference,
+                        review: review,
                         onRemove: () => widget.onRemove(index),
                       );
                     }).toList(),
@@ -120,18 +121,13 @@ class _AiReferencesAccordionState extends State<AiReferencesAccordion>
 }
 
 class _ReferenceCard extends StatelessWidget {
-  const _ReferenceCard({required this.reference, required this.onRemove});
+  const _ReferenceCard({required this.review, required this.onRemove});
 
-  final String reference;
+  final Review review;
   final VoidCallback onRemove;
 
   @override
   Widget build(BuildContext context) {
-    // Parse the reference to extract title and content
-    final lines = reference.split('\n');
-    final title = lines.first;
-    final content = lines.length > 1 ? lines.sublist(1).join('\n').trim() : '';
-
     return Container(
       padding: EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -146,7 +142,7 @@ class _ReferenceCard extends StatelessWidget {
             children: [
               Expanded(
                 child: Text(
-                  title,
+                  review.text,
                   style: GoogleFonts.inter(
                     fontSize: 12,
                     color: Colors.white,
@@ -171,18 +167,22 @@ class _ReferenceCard extends StatelessWidget {
               ),
             ],
           ),
-          if (content.isNotEmpty) ...[
-            SizedBox(height: 12),
-            Text(
-              content,
-              style: TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w400,
-                color: Colors.white.withValues(alpha: 0.8),
-                height: 1.4,
+          SizedBox(height: 8),
+          Container(
+            padding: EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              color: Colors.white.withAlpha(20),
+            ),
+            child: Text(
+              review.source,
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                fontWeight: FontWeight.w500,
+                color: Colors.white.withAlpha(153),
               ),
             ),
-          ],
+          ),
         ],
       ),
     );

--- a/lib/features/journal/widgets/reviews_bottom_sheet.dart
+++ b/lib/features/journal/widgets/reviews_bottom_sheet.dart
@@ -3,16 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:movie_journal/features/journal/controllers/journal.dart';
 import 'package:movie_journal/features/quesgen/provider.dart';
+import 'package:movie_journal/features/quesgen/review.dart';
 
-class QuestionItem extends StatelessWidget {
-  const QuestionItem({
+class ReviewItem extends StatelessWidget {
+  const ReviewItem({
     super.key,
-    required this.question,
+    required this.review,
     required this.isSelected,
     required this.onSelect,
   });
 
-  final String question;
+  final Review review;
   final bool isSelected;
   final VoidCallback onSelect;
 
@@ -32,13 +33,34 @@ class QuestionItem extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Flexible(
-              child: Text(
-                question,
-                style: GoogleFonts.inter(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w400,
-                  color: Colors.white,
-                ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 6,
+                children: [
+                  Text(
+                    review.text,
+                    style: GoogleFonts.inter(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w400,
+                      color: Colors.white,
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(8),
+                      color: Colors.white.withAlpha(20),
+                    ),
+                    child: Text(
+                      review.source,
+                      style: GoogleFonts.inter(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w500,
+                        color: Colors.white.withAlpha(153),
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
             InkWell(
@@ -59,13 +81,13 @@ class QuestionItem extends StatelessWidget {
   }
 }
 
-class QuestionsBottomSheet extends ConsumerWidget {
-  const QuestionsBottomSheet({super.key});
+class ReviewsBottomSheet extends ConsumerWidget {
+  const ReviewsBottomSheet({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final quesgenState = ref.watch(quesgenControllerProvider);
-    final questions = quesgenState.questions;
+    final reviews = quesgenState.reviews;
     final isLoading = quesgenState.isLoading;
     final journal = ref.watch(journalControllerProvider);
     final selectedRefs = journal.selectedRefs;
@@ -128,20 +150,20 @@ class QuestionsBottomSheet extends ConsumerWidget {
                             ),
                           ),
                         ]
-                        : questions.isNotEmpty
-                        ? questions.map(
-                          (question) => QuestionItem(
-                            question: question,
-                            isSelected: selectedRefs.contains(question),
+                        : reviews.isNotEmpty
+                        ? reviews.map(
+                          (review) => ReviewItem(
+                            review: review,
+                            isSelected: selectedRefs.contains(review),
                             onSelect: () {
-                              if (selectedRefs.contains(question)) {
+                              if (selectedRefs.contains(review)) {
                                 ref
                                     .read(journalControllerProvider.notifier)
-                                    .removeSelectedQuestion(question);
+                                    .removeSelectedReview(review);
                               } else {
                                 ref
                                     .read(journalControllerProvider.notifier)
-                                    .addSelectedQuestion(question);
+                                    .addSelectedReview(review);
                               }
                               Navigator.pop(context);
                             },
@@ -149,7 +171,7 @@ class QuestionsBottomSheet extends ConsumerWidget {
                         )
                         : [
                           Text(
-                            'No questions generated',
+                            'No reviews generated',
                             style: TextStyle(
                               fontSize: 14,
                               fontWeight: FontWeight.w500,
@@ -168,42 +190,6 @@ class QuestionsBottomSheet extends ConsumerWidget {
                   ),
                 ),
                 SizedBox(height: 16),
-                // ElevatedButton.icon(
-                //   icon: Icon(Icons.swap_horiz),
-                //   onPressed:
-                //       isLoading
-                //           ? null
-                //           : () {
-                //             final movie =
-                //                 ref.read(movieDetailControllerProvider).movie;
-                //             if (movie != null) {
-                //               ref
-                //                   .read(quesgenControllerProvider.notifier)
-                //                   .generateQuestions(movieId: movie.id);
-                //             }
-                //           },
-                //   style: ElevatedButton.styleFrom(
-                //     disabledBackgroundColor: Colors.transparent,
-                //     iconSize: 20,
-                //     shape: RoundedRectangleBorder(
-                //       borderRadius: BorderRadius.circular(16),
-                //     ),
-                //     foregroundColor: Colors.white,
-                //     iconColor: Colors.white,
-                //     overlayColor: Colors.white,
-                //     backgroundColor: Colors.transparent,
-                //     surfaceTintColor: Colors.transparent,
-                //     shadowColor: Colors.transparent,
-                //     textStyle: TextStyle(
-                //       fontSize: 14,
-                //       fontWeight: FontWeight.w500,
-                //       color: Colors.white,
-                //       fontFamily: 'AvenirNext',
-                //     ),
-                //   ),
-                //   label: Text('Regenerate'),
-                // ),
-                // SizedBox(height: 16),
               ],
             ),
           ),

--- a/lib/features/journal/widgets/thoughts_editor.dart
+++ b/lib/features/journal/widgets/thoughts_editor.dart
@@ -4,15 +4,16 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:movie_journal/features/journal/controllers/journal.dart';
 import 'package:movie_journal/features/journal/screens/thoughts.dart';
 import 'package:movie_journal/features/journal/widgets/ai_references_accordion.dart';
+import 'package:movie_journal/features/quesgen/review.dart';
 
-class SelectedQuestionItem extends StatelessWidget {
-  const SelectedQuestionItem({
+class SelectedReviewItem extends StatelessWidget {
+  const SelectedReviewItem({
     super.key,
-    required this.question,
+    required this.review,
     required this.onRemove,
   });
 
-  final String question;
+  final Review review;
   final VoidCallback onRemove;
 
   @override
@@ -30,7 +31,7 @@ class SelectedQuestionItem extends StatelessWidget {
         children: [
           Flexible(
             child: Text(
-              question,
+              review.text,
               style: GoogleFonts.inter(
                 fontSize: 14,
                 fontWeight: FontWeight.w400,
@@ -111,7 +112,7 @@ class ThoughtsEditor extends ConsumerWidget {
                 onRemove: (index) {
                   ref
                       .read(journalControllerProvider.notifier)
-                      .removeSelectedQuestion(selectedRefs[index]);
+                      .removeSelectedReview(selectedRefs[index]);
                 },
               )
               : SizedBox.shrink(),

--- a/lib/features/quesgen/api.dart
+++ b/lib/features/quesgen/api.dart
@@ -1,47 +1,15 @@
 import 'package:movie_journal/core/network/quesgen_dio_client.dart';
+import 'package:movie_journal/features/quesgen/review.dart';
 
-///  name: string;
-///  year: string;
-///  overview?: string;
-///  genres?: string[];
-///  runtime?: number;
-///  voteAverage?: number;
-///  productionCompanies?: string[];
-///  numOfQuestions?: number;
-///  language?: string;
-///  searchPrompt?: string;
-///  questionPrompt?: string;
 class QuesgenAPI {
-  Future<List<String>> generateQuestions({
+  Future<List<Review>> generateReviews({
     required int movieId,
-    // String? name,
-    // String? year,
-    // String? overview,
-    // List<String>? genres,
-    // int? runtime,
-    // double? voteAverage,
-    // List<String>? productionCompanies,
-    // int? numOfQuestions,
-    // String? language,
-    // String? searchPrompt,
-    // String? questionPrompt,
   }) async {
-    final response = await quesgenDioClient.post(
+    final response = await quesgenDioClient.get(
       '/generate/$movieId',
-      // data: {
-      //   'name': name,
-      //   'year': year,
-      //   'overview': overview,
-      //   'genres': genres,
-      //   'runtime': runtime,
-      //   'voteAverage': voteAverage,
-      //   'productionCompanies': productionCompanies,
-      //   'numOfQuestions': numOfQuestions,
-      //   'language': language,
-      //   'searchPrompt': searchPrompt,
-      //   'questionPrompt': questionPrompt,
-      // },
     );
-    return response.data['questions'].cast<String>();
+    return (response.data['reviews'] as List<dynamic>)
+        .map((item) => Review.fromMap(item as Map<String, dynamic>))
+        .toList();
   }
 }

--- a/lib/features/quesgen/controller.dart
+++ b/lib/features/quesgen/controller.dart
@@ -1,26 +1,27 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:movie_journal/features/quesgen/api.dart';
+import 'package:movie_journal/features/quesgen/review.dart';
 
 final quesgenApiProvider = Provider((_) => QuesgenAPI());
 
 class QuesgenState {
-  final List<String> questions;
+  final List<Review> reviews;
   final bool isLoading;
   final bool isError;
 
   QuesgenState({
-    required this.questions,
+    required this.reviews,
     required this.isLoading,
     required this.isError,
   });
 
   QuesgenState copyWith({
-    List<String>? questions,
+    List<Review>? reviews,
     bool? isLoading,
     bool? isError,
   }) {
     return QuesgenState(
-      questions: questions ?? this.questions,
+      reviews: reviews ?? this.reviews,
       isLoading: isLoading ?? this.isLoading,
       isError: isError ?? this.isError,
     );
@@ -30,48 +31,26 @@ class QuesgenState {
 class QuesgenController extends Notifier<QuesgenState> {
   @override
   QuesgenState build() {
-    return QuesgenState(questions: [], isLoading: false, isError: false);
+    return QuesgenState(reviews: [], isLoading: false, isError: false);
   }
 
-  Future<void> generateQuestions({
+  Future<void> generateReviews({
     required int movieId,
-    // String? name,
-    // String? year,
-    // String? overview,
-    // List<String>? genres,
-    // int? runtime,
-    // double? voteAverage,
-    // List<String>? productionCompanies,
-    // int? numOfQuestions,
-    // String? language,
-    // String? searchPrompt,
-    // String? questionPrompt,
   }) async {
     state = state.copyWith(isLoading: true);
     try {
-      final newQuestions = await ref
+      final newReviews = await ref
           .read(quesgenApiProvider)
-          .generateQuestions(
+          .generateReviews(
             movieId: movieId,
-            // name: name,
-            // year: year,
-            // overview: overview,
-            // genres: genres,
-            // runtime: runtime,
-            // voteAverage: voteAverage,
-            // productionCompanies: productionCompanies,
-            // numOfQuestions: numOfQuestions ?? 6,
-            // language: language,
-            // searchPrompt: searchPrompt,
-            // questionPrompt: questionPrompt,
           );
-      state = state.copyWith(questions: newQuestions, isLoading: false);
+      state = state.copyWith(reviews: newReviews, isLoading: false);
     } catch (e) {
       state = state.copyWith(isLoading: false, isError: true);
     }
   }
 
   void clear() {
-    state = state.copyWith(questions: [], isLoading: false, isError: false);
+    state = state.copyWith(reviews: [], isLoading: false, isError: false);
   }
 }

--- a/lib/features/quesgen/review.dart
+++ b/lib/features/quesgen/review.dart
@@ -1,0 +1,31 @@
+class Review {
+  final String text;
+  final String source; // "letterboxd", "reddit"
+
+  Review({required this.text, required this.source});
+
+  Map<String, dynamic> toMap() => {'text': text, 'source': source};
+
+  static Review fromMap(Map<String, dynamic> map) {
+    return Review(
+      text: map['text'] as String,
+      source: map['source'] as String,
+    );
+  }
+
+  // Backward compatibility: parse from old string format
+  static Review fromString(String text) {
+    return Review(text: text, source: 'unknown');
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Review &&
+          runtimeType == other.runtimeType &&
+          text == other.text &&
+          source == other.source;
+
+  @override
+  int get hashCode => text.hashCode ^ source.hashCode;
+}


### PR DESCRIPTION
## Summary
- Adapt to new quesgen API response schema: `{ reviews: [{ text, source }] }` replacing old `{ questions: string[] }`
- Add `Review` data model with `text` and `source` fields, backward-compatible deserialization from old `List<String>` format
- Rename all question-related naming (widgets, methods, state fields) to reviews across the codebase
- Update API call from POST to GET
- Display review source badges (letterboxd, reddit) in bottom sheet and accordion UI

## Test plan
- [ ] Verify existing journals with old `selectedRefs` format (plain strings) still load correctly
- [ ] Verify new reviews from API display with source badges in ReviewsBottomSheet
- [ ] Verify selecting/deselecting reviews updates journal state correctly
- [ ] Verify saved journals with new review format display properly in JournalContent
- [ ] Run `flutter analyze` — no new issues introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)