### PR TITLE
Add FocusNode handling to caption editor and wire autofocus to SceneCard

### DIFF
--- a/lib/features/journal/screens/caption_editor.dart
+++ b/lib/features/journal/screens/caption_editor.dart
@@ -17,6 +17,7 @@ class CaptionEditor extends ConsumerStatefulWidget {
 class _CaptionEditorState extends ConsumerState<CaptionEditor> {
   late PageController _pageController;
   late Map<String, TextEditingController> _captionControllers;
+  late Map<String, FocusNode> _captionFocusNodes;
   int _currentPage = 0;
 
   @override
@@ -29,12 +30,20 @@ class _CaptionEditorState extends ConsumerState<CaptionEditor> {
     // Initialize caption controllers for each scene
     final selectedScenes = ref.read(journalControllerProvider).selectedScenes;
     _captionControllers = {};
+    _captionFocusNodes = {};
 
     for (final scene in selectedScenes) {
       _captionControllers[scene.path] = TextEditingController(
         text: scene.caption ?? '',
       );
+      _captionFocusNodes[scene.path] = FocusNode();
     }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || selectedScenes.isEmpty) return;
+      final currentScene = selectedScenes[_currentPage];
+      _captionFocusNodes[currentScene.path]?.requestFocus();
+    });
   }
 
   @override
@@ -43,6 +52,9 @@ class _CaptionEditorState extends ConsumerState<CaptionEditor> {
     // Dispose all caption controllers
     for (final controller in _captionControllers.values) {
       controller.dispose();
+    }
+    for (final focusNode in _captionFocusNodes.values) {
+      focusNode.dispose();
     }
     super.dispose();
   }
@@ -63,6 +75,11 @@ class _CaptionEditorState extends ConsumerState<CaptionEditor> {
     setState(() {
       _currentPage = page;
     });
+
+    final selectedScenes = ref.read(journalControllerProvider).selectedScenes;
+    if (selectedScenes.isEmpty || page >= selectedScenes.length) return;
+    final currentScene = selectedScenes[page];
+    _captionFocusNodes[currentScene.path]?.requestFocus();
   }
 
   void _saveAllCaptions() {
@@ -115,6 +132,7 @@ class _CaptionEditorState extends ConsumerState<CaptionEditor> {
                   itemBuilder: (context, index) {
                     final scene = selectedScenes[index];
                     final controller = _captionControllers[scene.path];
+                    final focusNode = _captionFocusNodes[scene.path];
 
                     return SingleChildScrollView(
                       child: Padding(
@@ -122,6 +140,7 @@ class _CaptionEditorState extends ConsumerState<CaptionEditor> {
                         child: SceneCard(
                           imagePath: scene.path,
                           controller: controller,
+                          focusNode: focusNode,
                           isEditable: true,
                         ),
                       ),

--- a/lib/features/journal/widgets/scene_card.dart
+++ b/lib/features/journal/widgets/scene_card.dart
@@ -4,6 +4,7 @@ class SceneCard extends StatefulWidget {
   final String imagePath;
   final String? caption;
   final TextEditingController? controller;
+  final FocusNode? focusNode;
   final bool isEditable;
 
   const SceneCard({
@@ -11,6 +12,7 @@ class SceneCard extends StatefulWidget {
     required this.imagePath,
     this.caption,
     this.controller,
+    this.focusNode,
     this.isEditable = false,
   });
 
@@ -71,6 +73,7 @@ class _SceneCardState extends State<SceneCard> {
         TextField(
           enabled: widget.isEditable,
           controller: _effectiveController,
+          focusNode: widget.focusNode,
           style: TextStyle(
             color: Colors.white,
             fontSize: 13,


### PR DESCRIPTION
### Motivation
- Ensure the caption `TextField` is focused automatically when the caption editor opens and when the user swipes between scenes to improve editing UX.
- Maintain correct lifecycle management for focus nodes to avoid leaks when the editor is disposed.

### Description
- Add a `_captionFocusNodes` map to `CaptionEditor` to hold a `FocusNode` for each scene and initialize one per selected scene. 
- Request focus for the current scene after the first frame and on page changes via `_onPageChanged` so the `TextField` receives focus when its page is visible.
- Dispose all created `FocusNode`s in `dispose` alongside existing `TextEditingController` disposal.
- Extend `SceneCard` to accept a `focusNode` parameter and pass it into the editable `TextField` so the editor controls autofocus per scene.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a45ff1ac832e83d3be891ee2e869)