### PR TITLE
Add Firebase authentication token to Dio client requests

### DIFF
--- a/lib/core/network/quesgen_dio_client.dart
+++ b/lib/core/network/quesgen_dio_client.dart
@@ -1,7 +1,19 @@
 import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 final quesgenDioClient = Dio(
   BaseOptions(
     baseUrl: 'https://movie-journal-quesgen-929129412152.asia-east1.run.app',
   ),
-);
+)..interceptors.add(
+    QueuedInterceptorsWrapper(
+      onRequest: (options, handler) async {
+        final user = FirebaseAuth.instance.currentUser;
+        if (user != null) {
+          final token = await user.getIdToken();
+          options.headers['Authorization'] = 'Bearer $token';
+        }
+        handler.next(options);
+      },
+    ),
+  );


### PR DESCRIPTION
## Summary
Added automatic Firebase authentication token injection to all HTTP requests made through the Dio client by implementing a request interceptor.

## Key Changes
- Imported `firebase_auth` package to access current user authentication state
- Added a `QueuedInterceptorsWrapper` to the Dio client that intercepts all outgoing requests
- Implemented `onRequest` handler that:
  - Retrieves the current Firebase user
  - Obtains a fresh ID token from the authenticated user
  - Injects the token into the `Authorization` header with Bearer scheme
  - Allows the request to proceed with the updated headers

## Implementation Details
The interceptor runs on every request and only adds the authorization header if a user is currently authenticated. This ensures that all API calls to the backend are properly authenticated without requiring manual token management at the call site.

https://claude.ai/code/session_01WVNt88jffrXqhot88Ao4qa