### PR TITLE
feat: send system locale with AI review requests

### DIFF
--- a/lib/features/quesgen/api.dart
+++ b/lib/features/quesgen/api.dart
@@ -4,9 +4,11 @@ import 'package:movie_journal/features/quesgen/review.dart';
 class QuesgenAPI {
   Future<List<Review>> generateReviews({
     required int movieId,
+    String? locale,
   }) async {
     final response = await quesgenDioClient.get(
       '/generate/$movieId',
+      queryParameters: locale == null ? null : {'lang': locale},
     );
     return (response.data['reviews'] as List<dynamic>)
         .map((item) => Review.fromMap(item as Map<String, dynamic>))

--- a/lib/features/quesgen/controller.dart
+++ b/lib/features/quesgen/controller.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:movie_journal/features/quesgen/api.dart';
 import 'package:movie_journal/features/quesgen/review.dart';
@@ -39,10 +41,12 @@ class QuesgenController extends Notifier<QuesgenState> {
   }) async {
     state = state.copyWith(isLoading: true);
     try {
+      final locale = _toBackendLocaleTag(PlatformDispatcher.instance.locale);
       final newReviews = await ref
           .read(quesgenApiProvider)
           .generateReviews(
             movieId: movieId,
+            locale: locale,
           );
       state = state.copyWith(reviews: newReviews, isLoading: false);
     } catch (e) {
@@ -54,3 +58,22 @@ class QuesgenController extends Notifier<QuesgenState> {
     state = state.copyWith(reviews: [], isLoading: false, isError: false);
   }
 }
+
+/// Convert the OS-reported [Locale] into a BCP 47 tag the backend
+/// (and TMDB, in the future) understands.
+///
+/// - Combines [Locale.languageCode] with [Locale.countryCode] when present,
+///   e.g. `en_US` -> `"en-US"`.
+/// - Drops [Locale.scriptCode]. TMDB does not accept script subtags
+///   (`zh-Hant-TW` is invalid; `zh-TW` is correct). For CJK the country
+///   code already encodes the script (TW/HK -> Traditional, CN -> Simplified).
+/// - Returns `null` when the language code is missing so the caller can
+///   omit `?lang=` and let the server apply its own default.
+String? _toBackendLocaleTag(Locale locale) {
+  final language = locale.languageCode.trim();
+  if (language.isEmpty) return null;
+  final country = locale.countryCode;
+  if (country == null || country.isEmpty) return language;
+  return '$language-$country';
+}
+


### PR DESCRIPTION
## Summary

Detect the device's system locale and pass it to the AI Review backend as `?lang=<bcp47-tag>` so generated reviews come back in the user's language.

## What changed

- **`lib/features/quesgen/api.dart`**: `QuesgenAPI.generateReviews` accepts an optional `String? locale` and forwards it to Dio as `queryParameters: {'lang': locale}` when present.
- **`lib/features/quesgen/controller.dart`**:
  - Reads `PlatformDispatcher.instance.locale` (from `dart:ui`, no new deps, no `intl` / `l10n.yaml` setup needed).
  - Normalizes to a backend/TMDB-compatible BCP 47 tag via a small private `_toBackendLocaleTag` helper:
    - Combines `languageCode` + `countryCode` (`en_US` → `"en-US"`, `zh-Hant-TW` → `"zh-TW"`).
    - **Drops `scriptCode`** — TMDB rejects script subtags, and CJK country codes already encode the Traditional/Simplified distinction (TW/HK → Traditional, CN → Simplified), so this is lossless in practice.
    - Returns `null` if `languageCode` is empty, so the request omits `?lang` entirely and the server falls back to its default.

## Why

The AI Review feature currently always returns reviews in the server's default language. Localizing on the server side is the right architectural split (the LLM prompt owns the language instruction), but the backend needs the client to tell it what the user speaks. This PR provides that.

## Dependencies

- Backend support is already merged: [`isaackwok/movie-journal-quesgen#3`](https://github.com/isaackwok/movie-journal-quesgen/pull/3). Server maps common locales (en, zh-TW, zh-CN, ja, ko, es, fr, de, etc.) to prompt-language names and falls back to English for unknown tags, so rolling this client out is safe even if the server is on an older build (the param is just ignored).

## Notes for reviewer

- No new dependencies, no `intl` package, no `l10n.yaml`. The app still has no formal i18n — this is the minimum surface area to localize this one API call.
- The normalizer is deliberately placed as a file-private helper. If a second caller appears, promote it to `lib/core/locale/`.
- `?lang=` is safe to include even when the server doesn't understand the specific tag — the backend's `resolveLanguage` falls through to English.

## Test plan

- [ ] On iOS simulator: Settings → General → Language → set to `繁體中文 (台灣)`. Open a journal entry, tap the Reviews floating button, expect Traditional Chinese output.
- [ ] Switch simulator language to `English`. Tap Reviews on a different movie, expect English output.
- [ ] Verify outgoing request includes `?lang=zh-TW` (not `zh-Hant-TW`) via `flutter run -v` or a proxy like Charles.
- [ ] Switch to `日本語` — expect Japanese output and `?lang=ja`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)