### PR TITLE
Save spinner and AvenirNext typography polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,9 +238,9 @@ feature_name/
 ## UI/UX Guidelines
 
 ### Typography
-- **Google Fonts** are used throughout the app (e.g., Nothing You Could Do for usernames in Settings)
-- Access via `GoogleFonts` package with customizable font weights and sizes
-- Maintain consistent text styles across the app using theme definitions
+- **AvenirNext** is the primary UI font (registered in `pubspec.yaml` at weights 100–800, with Demi at w600). For inline bold accents in body text (emotion names, scene labels, date subtitles) use `fontFamily: 'AvenirNext'` with `FontWeight.w600` — not `.bold`/`.w700`, which falls back to a synthetic bold of the ambient font. The emotion-name typography is pinned by the `typography` group in `emotions_selector_button_test.dart`.
+- **Google Fonts** are used for specific display treatments — `Inter` for movie/journal titles, `Nothing You Could Do` for usernames in Settings. Access via the `google_fonts` package.
+- Theme colors via `Theme.of(context).colorScheme`.
 
 ### Theme
 - Supports light and dark themes (default: dark mode)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A Flutter movie journal app for capturing how films make you feel. Search for mo
 
 ```bash
 flutter analyze    # Static analysis
-flutter test       # Run 238 tests
+flutter test       # Run 240 tests
 flutter build apk  # Android build
 flutter build ios   # iOS build
 ```

--- a/lib/features/journal/screens/journaling.dart
+++ b/lib/features/journal/screens/journaling.dart
@@ -276,7 +276,23 @@ class _JournalingScreenState extends ConsumerState<JournalingScreen> {
                         return Colors.white;
                       }),
                     ),
-                    child: Text('Save'),
+                    child: _isSaving
+                        ? SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: Center(
+                            child: SizedBox(
+                              width: 14,
+                              height: 14,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: Colors.white,
+                                backgroundColor: Colors.white.withAlpha(50),
+                              ),
+                            ),
+                          ),
+                        )
+                        : const Text('Save'),
                   ),
                 ),
               ],

--- a/lib/features/journal/widgets/emotions_selector_bottom_sheet.dart
+++ b/lib/features/journal/widgets/emotions_selector_bottom_sheet.dart
@@ -342,7 +342,7 @@ class _EmotionsSelectorBottomSheetState
                         ),
                         SizedBox(height: 4),
                         Text(
-                          'select up to ${widget.maxSelectionLimit} (${_tempSelectedEmotions.length}/${widget.maxSelectionLimit})',
+                          'Select up to ${widget.maxSelectionLimit} (${_tempSelectedEmotions.length}/${widget.maxSelectionLimit})',
                           style: TextStyle(
                             fontFamily: 'AvenirNext',
                             fontSize: 14,

--- a/lib/features/journal/widgets/emotions_selector_button.dart
+++ b/lib/features/journal/widgets/emotions_selector_button.dart
@@ -76,96 +76,56 @@ class EmotionsSelectorButton extends StatelessWidget {
     }
   }
 
-  Widget _getButtonText(List selectedEmotions) {
+  static const _sentenceStyle = TextStyle(
+    color: Colors.white,
+    fontSize: 14,
+    fontWeight: FontWeight.w500,
+    fontFamily: 'AvenirNext',
+  );
+
+  static const _emotionNameStyle = TextStyle(
+    fontWeight: FontWeight.w600,
+    fontFamily: 'AvenirNext',
+  );
+
+  // Separators between successive emotion names, indexed by selection count.
+  // For 2 selections: "A and B". For 3: "A, B and C".
+  static const _separatorsByCount = <List<String>>[
+    [],              // 0 emotions
+    [],              // 1 emotion
+    [' and '],       // 2 emotions
+    [', ', ' and '], // 3 emotions
+  ];
+
+  TextSpan _emotionName(String name) =>
+      TextSpan(text: name, style: _emotionNameStyle);
+
+  Widget _getButtonText(List<Emotion> selectedEmotions) {
     if (selectedEmotions.isEmpty) {
-      return Text(
+      return const Text(
         'What are your feelings about this movie?',
-        style: TextStyle(
-          color: Colors.white,
-          fontSize: 14,
-          fontWeight: FontWeight.w500,
-          fontFamily: 'AvenirNext',
-        ),
+        style: _sentenceStyle,
       );
     }
 
-    final emotionNames =
+    final names =
         selectedEmotions.map((e) => e.name.toLowerCase()).toList();
+    final separators = _separatorsByCount[names.length];
 
-    if (emotionNames.length == 1) {
-      return Text.rich(
-        TextSpan(
-          style: TextStyle(
-            color: Colors.white,
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-            fontFamily: 'AvenirNext',
-          ),
-          children: [
-            TextSpan(text: 'You felt '),
-            TextSpan(
-              text: emotionNames[0],
-              style: TextStyle(fontWeight: FontWeight.w700),
-            ),
-            TextSpan(text: ' by this movie.'),
+    return Text.rich(
+      TextSpan(
+        style: _sentenceStyle,
+        children: [
+          const TextSpan(text: 'You felt '),
+          _emotionName(names.first),
+          for (var i = 1; i < names.length; i++) ...[
+            TextSpan(text: separators[i - 1]),
+            _emotionName(names[i]),
           ],
-        ),
-      );
-    } else if (emotionNames.length == 2) {
-      return Text.rich(
-        TextSpan(
-          style: TextStyle(
-            color: Colors.white,
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-            fontFamily: 'AvenirNext',
-          ),
-          children: [
-            TextSpan(text: 'You felt '),
-            TextSpan(
-              text: emotionNames[0],
-              style: TextStyle(fontWeight: FontWeight.w700),
-            ),
-            TextSpan(text: ' and '),
-            TextSpan(
-              text: emotionNames[1],
-              style: TextStyle(fontWeight: FontWeight.w700),
-            ),
-            TextSpan(text: ' by this movie.'),
-          ],
-        ),
-      );
-    } else {
-      // 3 emotions
-      return Text.rich(
-        TextSpan(
-          style: TextStyle(
-            color: Colors.white,
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-            fontFamily: 'AvenirNext',
-          ),
-          children: [
-            TextSpan(text: 'You felt '),
-            TextSpan(
-              text: emotionNames[0],
-              style: TextStyle(fontWeight: FontWeight.w700),
-            ),
-            TextSpan(text: ', '),
-            TextSpan(
-              text: emotionNames[1],
-              style: TextStyle(fontWeight: FontWeight.w700),
-            ),
-            TextSpan(text: ' and '),
-            TextSpan(
-              text: emotionNames[2],
-              style: TextStyle(fontWeight: FontWeight.w700),
-            ),
-            TextSpan(text: ' by this movie.'),
-          ],
-        ),
-      );
-    }
+          const TextSpan(text: ' by this movie.'),
+        ],
+      ),
+    );
   }
 
   @override

--- a/lib/features/journal/widgets/scenes_selector.dart
+++ b/lib/features/journal/widgets/scenes_selector.dart
@@ -204,7 +204,7 @@ class _ScenesSelectorState extends ConsumerState<ScenesSelector> {
                         style: const TextStyle(
                           color: Colors.white,
                           fontSize: 14,
-                          fontWeight: FontWeight.bold,
+                          fontWeight: FontWeight.w600,
                           fontFamily: 'AvenirNext',
                         ),
                       ),

--- a/test/features/journal/widgets/emotions_selector_bottom_sheet_test.dart
+++ b/test/features/journal/widgets/emotions_selector_bottom_sheet_test.dart
@@ -44,7 +44,7 @@ void main() {
           (tester) async {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
-        expect(find.text('select up to 3 (0/3)'), findsOneWidget);
+        expect(find.text('Select up to 3 (0/3)'), findsOneWidget);
       });
 
       testWidgets('counter reflects initial emotions count', (tester) async {
@@ -52,7 +52,7 @@ void main() {
           initialEmotions: [emotionList[EmotionType.joyful]!],
         ));
         await tester.pumpAndSettle();
-        expect(find.text('select up to 3 (1/3)'), findsOneWidget);
+        expect(find.text('Select up to 3 (1/3)'), findsOneWidget);
       });
 
       testWidgets('displays close icon button', (tester) async {
@@ -112,7 +112,7 @@ void main() {
         await tester.tap(find.text('Joyful'));
         await tester.pumpAndSettle();
 
-        expect(find.text('select up to 3 (1/3)'), findsOneWidget);
+        expect(find.text('Select up to 3 (1/3)'), findsOneWidget);
       });
 
       testWidgets('tapping a second emotion updates counter to 2',
@@ -125,7 +125,7 @@ void main() {
         await tester.tap(find.text('Angry'));
         await tester.pumpAndSettle();
 
-        expect(find.text('select up to 3 (2/3)'), findsOneWidget);
+        expect(find.text('Select up to 3 (2/3)'), findsOneWidget);
       });
 
       testWidgets('cannot select more than 3 emotions', (tester) async {
@@ -139,12 +139,12 @@ void main() {
         await tester.pumpAndSettle();
         await tester.tap(find.text('Shocked'));
         await tester.pumpAndSettle();
-        expect(find.text('select up to 3 (3/3)'), findsOneWidget);
+        expect(find.text('Select up to 3 (3/3)'), findsOneWidget);
 
         // Try to select a 4th — counter should stay at 3/3
         await tester.tap(find.text('Funny'));
         await tester.pumpAndSettle();
-        expect(find.text('select up to 3 (3/3)'), findsOneWidget);
+        expect(find.text('Select up to 3 (3/3)'), findsOneWidget);
       });
 
       testWidgets('tapping a selected emotion deselects it', (tester) async {
@@ -152,13 +152,13 @@ void main() {
           initialEmotions: [emotionList[EmotionType.joyful]!],
         ));
         await tester.pumpAndSettle();
-        expect(find.text('select up to 3 (1/3)'), findsOneWidget);
+        expect(find.text('Select up to 3 (1/3)'), findsOneWidget);
 
         // Tap Joyful to deselect
         await tester.tap(find.text('Joyful'));
         await tester.pumpAndSettle();
 
-        expect(find.text('select up to 3 (0/3)'), findsOneWidget);
+        expect(find.text('Select up to 3 (0/3)'), findsOneWidget);
       });
     });
 

--- a/test/features/journal/widgets/emotions_selector_button_test.dart
+++ b/test/features/journal/widgets/emotions_selector_button_test.dart
@@ -92,6 +92,57 @@ void main() {
       });
     });
 
+    group('typography', () {
+      TextSpan? findSpanByText(InlineSpan span, String target) {
+        if (span is TextSpan) {
+          if (span.text == target) return span;
+          for (final child in span.children ?? const <InlineSpan>[]) {
+            final hit = findSpanByText(child, target);
+            if (hit != null) return hit;
+          }
+        }
+        return null;
+      }
+
+      TextSpan? findEmotionSpan(WidgetTester tester, String emotionName) {
+        for (final rt in tester.widgetList<RichText>(find.byType(RichText))) {
+          final hit = findSpanByText(rt.text, emotionName);
+          if (hit != null) return hit;
+        }
+        return null;
+      }
+
+      testWidgets('emotion name renders in AvenirNext at w600',
+          (tester) async {
+        await tester.pumpWidget(buildSubject(
+          emotions: [emotionList[EmotionType.joyful]!],
+        ));
+
+        final span = findEmotionSpan(tester, 'joyful');
+        expect(span, isNotNull);
+        expect(span!.style?.fontWeight, FontWeight.w600);
+        expect(span.style?.fontFamily, 'AvenirNext');
+      });
+
+      testWidgets('all emotion names share the same typography when multiple',
+          (tester) async {
+        await tester.pumpWidget(buildSubject(
+          emotions: [
+            emotionList[EmotionType.joyful]!,
+            emotionList[EmotionType.inspired]!,
+            emotionList[EmotionType.hopeful]!,
+          ],
+        ));
+
+        for (final name in ['joyful', 'inspired', 'hopeful']) {
+          final span = findEmotionSpan(tester, name);
+          expect(span, isNotNull, reason: 'missing span for $name');
+          expect(span!.style?.fontWeight, FontWeight.w600);
+          expect(span.style?.fontFamily, 'AvenirNext');
+        }
+      });
+    });
+
     group('selected state', () {
       testWidgets('shows edit icon when emotions are selected',
           (tester) async {


### PR DESCRIPTION
## Summary
- **Save button spinner** — the journaling screen's Save button now shows a small white `CircularProgressIndicator` while the Firestore save is in-flight. Reuses the existing `_isSaving` flag that already gates the button's disabled styling (no new state plumbing).
- **AvenirNext consolidation** — emotion-name spans and one scenes-selector label switched to `fontFamily: 'AvenirNext'` with `FontWeight.w600` (matching the Demi weight registered in commit 83eb6a0). Avoids synthetic bold fallback on the ambient font.
- **`_getButtonText` refactor** — three near-identical branches (1/2/3 emotions) collapsed into a single table-driven builder: shared styles promoted to `static const`, separators extracted into `_separatorsByCount[N]`, and a reusable `_emotionName(String)` helper produces the styled span.
- **Typography test** — new `typography` group in `emotions_selector_button_test.dart` pins AvenirNext/w600 styling via a recursive `InlineSpan` walker, guarding against weight/family drift.
- **Docs** — CLAUDE.md Typography section rewritten to reflect AvenirNext as the primary UI font (prior text inaccurately claimed Google Fonts was used "throughout"); README test count bumped 238 → 240.

## Test plan
- [x] \`flutter test\` — all 240 pass
- [x] \`flutter analyze\` — clean on modified files
- [x] Open journal editor, fill content, tap Save — spinner visible during save; button returns to "Save" text on error
- [x] Select 1 / 2 / 3 emotions — sentences render identically to before ("You felt A" / "You felt A and B" / "You felt A, B and C by this movie.") with bold emotion names in AvenirNext

🤖 Generated with [Claude Code](https://claude.com/claude-code)