### PR TITLE
fix(onboarding): home showed 'User' instead of chosen username

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ Uses **Riverpod** for state management:
    - CreateUserScreen for new users → Set username → Store in Firestore
    - Journals synced by userId field in Firestore documents
    - **Logout/Delete**: SettingsScreen invalidates `journalsControllerProvider` and `currentUsernameProvider` before navigating via `pushAndRemoveUntil`. Don't pop dialogs before calling the handler — `showDialog`'s `builder: (context)` shadows the outer context and popping it unmounts the dialog context.
+   - **Onboarding (create user) must invalidate `currentUsernameProvider`**: `main.dart` eagerly subscribes to it via `ref.listenManual(..., fireImmediately: true)` for analytics, so at app startup for a first-time signup the provider runs while `users/{uid}` doesn't exist yet, resolves to the `'User'` fallback, and caches it. After `_createUser()` writes the doc in `CreateUserScreen`, call `ref.invalidate(currentUsernameProvider)` before navigating to `HomeScreen` or the home will display `'User'` instead of the chosen name.
    - **Delete Account ordering (gotcha)**: `_deleteAccount()` must call `FirebaseManager.reauthenticate()` *before* any destructive action. Otherwise `currentUser.delete()` fails with `requires-recent-login` after Firestore data is already gone, leaving an unrecoverable half-deleted state. Order: reauthenticate → `FirestoreManager.deleteUser()` → log analytics per deleted journal id → `currentUser.delete()`.
 
 ## Key Dependencies

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Flutter movie journal app for capturing how films make you feel. Search for mo
 - **AI-Curated Reviews** — Browse reviews from Letterboxd and Reddit to spark your own thoughts
 - **Shareable Movie Tickets** — Generate flippable movie ticket images with high-res poster front and details back, peek hint animation on entry. Tap the ticket to flip, then use the bottom action row to save to gallery or open the share sheet (Instagram Stories, Threads, or native share). Close (X) in the top-right exits the flow straight to the journal's content page.
 - **Poster Picker** — Choose ticket posters in multiple languages (Original, English, 繁體中文, 日本語)
-- **Account Management** — Sign in with Apple or Google. Deleting your account performs a fresh re-authentication and then permanently removes all your journals and account data — no orphaned records left behind.
+- **Account Management** — Sign in with Apple or Google, then pick a username during onboarding that appears on your home screen. Deleting your account performs a fresh re-authentication and then permanently removes all your journals and account data — no orphaned records left behind.
 
 ## Getting Started
 
@@ -72,7 +72,7 @@ A Flutter movie journal app for capturing how films make you feel. Search for mo
 
 ```bash
 flutter analyze    # Static analysis
-flutter test       # Run 240 tests
+flutter test       # Run 244 tests
 flutter build apk  # Android build
 flutter build ios   # iOS build
 ```

--- a/lib/features/login/screens/create_user.dart
+++ b/lib/features/login/screens/create_user.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:movie_journal/analytics_manager.dart';
@@ -37,16 +38,16 @@ String? validateUsername(String username) {
   return null; // Valid
 }
 
-class CreateUserScreen extends StatefulWidget {
+class CreateUserScreen extends ConsumerStatefulWidget {
   const CreateUserScreen({super.key});
 
   @override
-  State<CreateUserScreen> createState() => _CreateUserScreenState();
+  ConsumerState<CreateUserScreen> createState() => _CreateUserScreenState();
 }
 
-class _CreateUserScreenState extends State<CreateUserScreen> {
+class _CreateUserScreenState extends ConsumerState<CreateUserScreen> {
   final TextEditingController _usernameController = TextEditingController();
-  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  FirebaseFirestore get _firestore => FirebaseFirestore.instance;
   bool _isLoading = false;
 
   @override
@@ -113,6 +114,9 @@ class _CreateUserScreenState extends State<CreateUserScreen> {
       // All checks passed - create user
       var newUserDoc = await _createUser(username);
       await _uploadLocalJournals(newUserDoc);
+      // The provider was evaluated at app startup (before this doc existed)
+      // and cached the 'User' fallback — invalidate so HomeScreen re-fetches.
+      ref.invalidate(currentUsernameProvider);
       final providerId = FirebaseAuth.instance.currentUser?.providerData
           .firstOrNull?.providerId ?? 'unknown';
       AnalyticsManager.logSignUp(method: providerId);

--- a/test/features/login/screens/create_user_test.dart
+++ b/test/features/login/screens/create_user_test.dart
@@ -1,8 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:movie_journal/features/login/screens/create_user.dart';
 
-// Note: create_user.dart now includes AnalyticsManager calls (screen view + sign_up event).
-// These are no-ops without Firebase and don't affect validateUsername() tests below.
+import '../../../helpers/widget_test_setup.dart';
+
+// Note: create_user.dart includes AnalyticsManager calls (screen view + sign_up event)
+// and is now a ConsumerStatefulWidget so it can invalidate currentUsernameProvider
+// after onboarding writes the user doc. AnalyticsManager is a no-op without Firebase,
+// and the Firestore calls in _handleStartJournaling only fire on button press, so the
+// rendering tests below mount the screen safely.
 
 void main() {
   group('validateUsername', () {
@@ -131,6 +138,41 @@ void main() {
       test('allows leading underscore', () {
         expect(validateUsername('_john'), isNull);
       });
+    });
+  });
+
+  group('CreateUserScreen rendering', () {
+    setUpAll(() => setUpWidgetTests());
+    tearDownAll(() => tearDownWidgetTests());
+
+    Widget buildSubject() {
+      return const ProviderScope(
+        child: MaterialApp(home: CreateUserScreen()),
+      );
+    }
+
+    testWidgets('mounts inside a ProviderScope without throwing',
+        (tester) async {
+      await tester.pumpWidget(buildSubject());
+      expect(find.byType(CreateUserScreen), findsOneWidget);
+    });
+
+    testWidgets('renders the Pick a name title', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      expect(find.text('Pick a name.'), findsOneWidget);
+    });
+
+    testWidgets('renders the username input field', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      expect(find.byType(TextField), findsOneWidget);
+    });
+
+    testWidgets('renders the Start Journaling button', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      expect(
+        find.widgetWithText(ElevatedButton, 'Start Journaling'),
+        findsOneWidget,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- Onboarding wrote the correct username to Firestore, but HomeScreen showed the `'User'` fallback. Root cause: `main.dart`'s `ref.listenManual(currentUsernameProvider, fireImmediately: true)` evaluates the provider at app startup, before `users/{uid}` exists, so the provider resolves to and caches the fallback — nothing re-fetches after the write.
- Fix: `ref.invalidate(currentUsernameProvider)` in `_handleStartJournaling` right after the Firestore write. Mirrors the existing pattern in settings (rename / delete account).
- Incidental: swap the `FirebaseFirestore` field initializer for a getter so `CreateUserScreen` can be mounted in widget tests without Firebase init (matches the `AnalyticsManager._analytics` getter pattern). Adds 4 rendering smoke tests that would fail if the field-initializer regression is reintroduced.

## Test plan
- [ ] Delete the Firestore `users/{uid}` doc (or sign in with a fresh Apple/Google account), run onboarding, confirm HomeScreen shows the chosen username (not `'User'`).
- [x] `flutter analyze` — clean.
- [x] `flutter test` — 244/244 pass (21 existing validateUsername + 4 new CreateUserScreen rendering tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)