### PR TITLE
refactor(auth): move auth providers out of home.dart into features/auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ flutter pub outdated
 
 The app follows a feature-based architecture where each feature is self-contained in `lib/features/`:
 
+- **auth/** - `auth_providers.dart`: the app-wide auth providers, importable without dragging in any screen — `authStateProvider` (Supabase auth stream), `currentUsernameProvider`, `anonymousBridgeProvider` (one-shot pre-login migration bridge), `hasProfileProvider` (HomeScreen vs CreateUserScreen; runs `claim_migrated_data()` once on a missing profile). Moved out of `home/screens/home.dart` (ISA-11) so features stop importing a screen file to reach auth state.
+
 - **home/** - Main dashboard: journal entries list, empty state, add movie button
   - `screens/` - HomeScreen. Empty state renders `EmptyPlaceholder` outside `SingleChildScrollView` (needs bounded height for `LayoutBuilder`); non-empty state wraps `JournalsList` in `SingleChildScrollView`.
   - `widgets/` - JournalCard, JournalsList, EmptyPlaceholder, AddMovieButton.

--- a/lib/features/account_link/controllers/account_link.dart
+++ b/lib/features/account_link/controllers/account_link.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:movie_journal/features/home/screens/home.dart';
+import 'package:movie_journal/features/auth/auth_providers.dart';
 import 'package:movie_journal/supabase_auth_manager.dart';
 
 /// Seam between the link UI and the auth SDK.

--- a/lib/features/auth/auth_providers.dart
+++ b/lib/features/auth/auth_providers.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:movie_journal/anonymous_bridge.dart';
+import 'package:movie_journal/supabase_auth_manager.dart';
+import 'package:movie_journal/supabase_db_manager.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Provider that streams Supabase authentication state changes
+/// Returns the current User or null if not authenticated
+final authStateProvider = StreamProvider<User?>((ref) {
+  return SupabaseAuthManager.authStateChanges;
+});
+
+/// Provider that fetches the current user's username from `profiles`
+final currentUsernameProvider = FutureProvider<String>((ref) async {
+  final authState = await ref.watch(authStateProvider.future);
+  if (authState == null) {
+    return 'Guest';
+  }
+
+  final userData = await SupabaseDbManager().getUser(authState.id);
+  return userData?['username'] ?? 'User';
+});
+
+/// Runs the pre-migration anonymous-account bridge once per app start, before
+/// a signed-out user is offered the login screen. See [AnonymousBridge].
+///
+/// Returns `false` fast (no network) for the common case of a device with no
+/// Firebase anonymous session.
+final anonymousBridgeProvider = FutureProvider<bool>((ref) async {
+  return AnonymousBridge.attempt();
+});
+
+/// Whether the signed-in user already has a `profiles` row — i.e. whether to
+/// show HomeScreen or CreateUserScreen.
+///
+/// A missing profile is ambiguous during the migration window. It means either
+/// a genuinely new user, OR a migrated user whose sign-in did not attach to
+/// their pre-created account (their provider email changed since the export,
+/// so Supabase's email auto-linking had nothing to match on). The second case
+/// is why `claim_migrated_data()` exists: it matches on the provider `sub` via
+/// `firebase_identity_map` and re-points the pre-created profile + journals to
+/// the caller.
+///
+/// This lives in a provider, not in the `FutureBuilder` it replaced, because
+/// `FutureBuilder(future: <inline expression>)` re-evaluates on every rebuild.
+/// The claim RPC must run at most once per sign-in; Riverpod's caching is what
+/// makes that true.
+final hasProfileProvider = FutureProvider<bool>((ref) async {
+  final user = await ref.watch(authStateProvider.future);
+  if (user == null) return false;
+
+  final db = SupabaseDbManager();
+  if (await db.userExists(user.id)) return true;
+
+  // No profile row. Attempt the claim, then re-check: `claimMigratedData`
+  // returns 'no_mapping' for a genuinely new user (not an error), and
+  // 'claimed' after re-pointing a migrated user's data to this account.
+  // Fail CLOSED, deliberately. Swallowing this and returning false would send
+  // the user to CreateUserScreen, and a migrated user who creates a second
+  // profile there strands their imported journals under the pre-created
+  // account — recoverable only by hand. A surfaced error is retryable; a
+  // duplicate profile is not, so the error is the better failure.
+  await db.claimMigratedData();
+  return db.userExists(user.id);
+});

--- a/lib/features/home/screens/home.dart
+++ b/lib/features/home/screens/home.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:movie_journal/analytics_manager.dart';
-import 'package:movie_journal/anonymous_bridge.dart';
 import 'package:movie_journal/features/account_link/widgets/secure_account_banner.dart';
+import 'package:movie_journal/features/auth/auth_providers.dart';
 import 'package:movie_journal/features/home/widgets/add_movie_button.dart';
 import 'package:movie_journal/features/home/widgets/empty_placeholder.dart';
 import 'package:movie_journal/features/home/widgets/journals_list.dart';
@@ -13,68 +13,6 @@ import 'package:movie_journal/features/login/screens/create_user.dart';
 import 'package:movie_journal/features/onboarding/controllers/splash_shown.dart';
 import 'package:movie_journal/features/onboarding/screens/branding_splash.dart';
 import 'package:movie_journal/features/settings/screens/settings.dart';
-import 'package:movie_journal/supabase_auth_manager.dart';
-import 'package:movie_journal/supabase_db_manager.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
-
-/// Provider that streams Supabase authentication state changes
-/// Returns the current User or null if not authenticated
-final authStateProvider = StreamProvider<User?>((ref) {
-  return SupabaseAuthManager.authStateChanges;
-});
-
-/// Provider that fetches the current user's username from `profiles`
-final currentUsernameProvider = FutureProvider<String>((ref) async {
-  final authState = await ref.watch(authStateProvider.future);
-  if (authState == null) {
-    return 'Guest';
-  }
-
-  final userData = await SupabaseDbManager().getUser(authState.id);
-  return userData?['username'] ?? 'User';
-});
-
-/// A missing profile is ambiguous during the migration window. It means either
-/// a genuinely new user, OR a migrated user whose sign-in did not attach to
-/// their pre-created account (their provider email changed since the export,
-/// so Supabase's email auto-linking had nothing to match on). The second case
-/// is why `claim_migrated_data()` exists: it matches on the provider `sub` via
-/// `firebase_identity_map` and re-points the pre-created profile + journals to
-/// the caller.
-///
-/// This lives in a provider, not in the `FutureBuilder` it replaced, because
-/// `FutureBuilder(future: <inline expression>)` re-evaluates on every rebuild.
-/// The claim RPC must run at most once per sign-in; Riverpod's caching is what
-/// makes that true.
-/// Runs the pre-migration anonymous-account bridge once per app start, before
-/// a signed-out user is offered the login screen. See [AnonymousBridge].
-///
-/// Returns `false` fast (no network) for the common case of a device with no
-/// Firebase anonymous session.
-final anonymousBridgeProvider = FutureProvider<bool>((ref) async {
-  return AnonymousBridge.attempt();
-});
-
-/// Whether the signed-in user already has a `profiles` row — i.e. whether to
-/// show HomeScreen or CreateUserScreen.
-final hasProfileProvider = FutureProvider<bool>((ref) async {
-  final user = await ref.watch(authStateProvider.future);
-  if (user == null) return false;
-
-  final db = SupabaseDbManager();
-  if (await db.userExists(user.id)) return true;
-
-  // No profile row. Attempt the claim, then re-check: `claimMigratedData`
-  // returns 'no_mapping' for a genuinely new user (not an error), and
-  // 'claimed' after re-pointing a migrated user's data to this account.
-  // Fail CLOSED, deliberately. Swallowing this and returning false would send
-  // the user to CreateUserScreen, and a migrated user who creates a second
-  // profile there strands their imported journals under the pre-created
-  // account — recoverable only by hand. A surfaced error is retryable; a
-  // duplicate profile is not, so the error is the better failure.
-  await db.claimMigratedData();
-  return db.userExists(user.id);
-});
 
 /// Reusable loading widget with centered circular progress indicator
 class LoadingScaffold extends StatelessWidget {

--- a/lib/features/login/screens/create_user.dart
+++ b/lib/features/login/screens/create_user.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:movie_journal/analytics_manager.dart';
+import 'package:movie_journal/features/auth/auth_providers.dart';
 import 'package:movie_journal/features/home/screens/home.dart';
 import 'package:movie_journal/supabase_auth_manager.dart';
 import 'package:movie_journal/supabase_db_manager.dart';

--- a/lib/features/settings/screens/settings.dart
+++ b/lib/features/settings/screens/settings.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:movie_journal/analytics_manager.dart';
 import 'package:movie_journal/features/account_link/controllers/account_link.dart';
 import 'package:movie_journal/features/account_link/widgets/secure_account_sheet.dart';
+import 'package:movie_journal/features/auth/auth_providers.dart';
 import 'package:movie_journal/features/home/screens/home.dart';
 import 'package:movie_journal/supabase_auth_manager.dart';
 import 'package:movie_journal/features/journal/controllers/journals.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:movie_journal/analytics_manager.dart';
+import 'package:movie_journal/features/auth/auth_providers.dart';
 import 'package:movie_journal/features/home/screens/home.dart';
 import 'package:movie_journal/supabase_auth_manager.dart';
 import 'package:movie_journal/themes.dart';

--- a/test/features/account_link/controllers/account_link_test.dart
+++ b/test/features/account_link/controllers/account_link_test.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:movie_journal/features/account_link/controllers/account_link.dart';
-import 'package:movie_journal/features/home/screens/home.dart';
+import 'package:movie_journal/features/auth/auth_providers.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 User _user({bool isAnonymous = false}) => User(


### PR DESCRIPTION
## Summary
- Extracts `authStateProvider`, `currentUsernameProvider`, `anonymousBridgeProvider`, and `hasProfileProvider` from `lib/features/home/screens/home.dart` into a new `lib/features/auth/auth_providers.dart` — features no longer import a screen file to reach auth state (ISA-11 item 1, ISA-7 Phase 4).
- Pure move, no behavior change; call sites in `main.dart`, `account_link`, `create_user`, `settings` (and the account_link test) now import the provider file. Reattached a doc comment that had drifted from its provider.
- CLAUDE.md updated with the new **auth/** feature entry.

## Verification
- `flutter analyze`: clean (only the pre-existing missing-`.env` asset warning).
- `flutter test`: 332 passed, 0 failed.

Part of ISA-11 / ISA-7 Phase 4. Next PRs: SceneButton rename, helper consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)