### PR TITLE
refactor(journal): resolve SceneButton name collision

### DIFF
--- a/lib/features/journal/widgets/scenes_select_sheet.dart
+++ b/lib/features/journal/widgets/scenes_select_sheet.dart
@@ -7,8 +7,8 @@ import 'package:movie_journal/features/movie/data/models/movie_image.dart';
 import 'package:movie_journal/features/toast/custom_toast.dart';
 import 'package:movie_journal/shared_widgets/action_text_button.dart';
 
-class SceneButton extends StatelessWidget {
-  const SceneButton({
+class SceneGridTile extends StatelessWidget {
+  const SceneGridTile({
     super.key,
     required this.index,
     required this.imageUrl,
@@ -154,7 +154,7 @@ class _ScenesSelectSheetState extends ConsumerState<ScenesSelectSheet> {
                       (scene) => scene.path == backdrop.filePath,
                     );
 
-                    return SceneButton(
+                    return SceneGridTile(
                       index: selectedIndex,
                       imageUrl:
                           'https://image.tmdb.org/t/p/w500${backdrops[index].filePath}',

--- a/lib/features/journal/widgets/scenes_selector.dart
+++ b/lib/features/journal/widgets/scenes_selector.dart
@@ -6,8 +6,8 @@ import 'package:movie_journal/features/journal/widgets/scenes_select_sheet.dart'
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
 
-class SceneButton extends StatelessWidget {
-  const SceneButton({
+class SelectedSceneCard extends StatelessWidget {
+  const SelectedSceneCard({
     super.key,
     required this.imageUrl,
     required this.onRemove,
@@ -206,7 +206,7 @@ class _ScenesSelectorState extends ConsumerState<ScenesSelector> {
             separatorBuilder: (context, index) => const SizedBox(width: 8),
             itemBuilder: (context, index) {
               final scene = selectedScenes[index];
-              return SceneButton(
+              return SelectedSceneCard(
                 imageUrl: 'https://image.tmdb.org/t/p/w500${scene.path}',
                 sceneIndex: index,
                 caption: scene.caption,

--- a/test/features/journal/widgets/scenes_select_sheet_test.dart
+++ b/test/features/journal/widgets/scenes_select_sheet_test.dart
@@ -75,7 +75,7 @@ void main() {
       await tester.pumpWidget(buildSubject(container));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(SceneButton).first);
+      await tester.tap(find.byType(SceneGridTile).first);
       await tester.pump();
 
       expect(find.text('Select up to 10 (1/10)'), findsOneWidget);
@@ -97,13 +97,13 @@ void main() {
 
       // Fill the cap.
       for (var i = 0; i < 10; i++) {
-        await tester.tap(find.byType(SceneButton).at(i));
+        await tester.tap(find.byType(SceneGridTile).at(i));
         await tester.pump();
       }
       expect(find.text('Select up to 10 (10/10)'), findsOneWidget);
 
       // Tapping an 11th is blocked: count holds at 10/10 and a toast appears.
-      await tester.tap(find.byType(SceneButton).at(10));
+      await tester.tap(find.byType(SceneGridTile).at(10));
       await tester.pump();
       expect(find.text('Select up to 10 (10/10)'), findsOneWidget);
       expect(find.text('You can select up to 10 scenes'), findsWidgets);


### PR DESCRIPTION
## Summary
- Two unrelated public widgets were both named `SceneButton` (`scenes_selector.dart:9` and `scenes_select_sheet.dart:10`); the former only compiled because its local declaration shadowed the import. Renamed by role (ISA-11 item 2, ISA-7 Phase 4):
  - `scenes_selector.dart`: `SceneButton` → `SelectedSceneCard` (selected scene with remove button; tap opens `CaptionEditor`)
  - `scenes_select_sheet.dart`: `SceneButton` → `SceneGridTile` (picker grid tile with selection border)
- Pure rename, no behavior change. Test finders updated in `scenes_select_sheet_test.dart`.

## Verification
- `flutter analyze`: No issues found.
- `flutter test`: 332 passed, 0 failed.

Part of ISA-11 / ISA-7 Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)