### PR TITLE
refactor: consolidate presentation helpers (tmdbImageUrl, SheetAppBar, toast fold, one tracking idiom)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ The app follows a feature-based architecture where each feature is self-containe
 - **journal/** - Core journaling features with full workflow from movie selection to saving
   - `controllers/` - JournalState (single journal), JournalsState (list of journals), JournalMode enum + JournalModeNotifier (create/edit mode)
   - `screens/` - Journaling (main editor), JournalComplete (post-save success screen), JournalContent (view saved journal), MoviePreview, ThoughtsScreen (`thoughts.dart`), CaptionEditor. Note `ThoughtsScreen` (screen) and `ThoughtsEditor` (widget, below) are different classes — don't confuse them.
-  - `widgets/` - EmotionsSelectorButton, EmotionsSelectorBottomSheet, ScenesSelector, ScenesSelectSheet, SceneCard, ReviewItem, ReviewsBottomSheet, ThoughtsEditor, AiReferencesAccordion, JournalContentMoreMenu, and `journal_actions.dart` — a set of shared helper functions (`editJournal`, `shareJournal`, `confirmDeleteJournal`, `deleteJournal`) that encapsulate the domain actions a journal can undergo. Reused by both the more-menu on `JournalContent` and the long-press menu on `JournalCard`. The helpers own the *domain action* (load state / navigate to editor, confirm dialog, Supabase delete + toast, navigate to `TicketPosterPickerScreen`) but intentionally leave post-action navigation (e.g. popping after delete) to the caller, since that depends on which screen initiated the action.
+  - `widgets/` - EmotionsSelectorButton, EmotionsSelectorBottomSheet, ScenesSelector (whose selected-scene card is `SelectedSceneCard`), ScenesSelectSheet (whose grid tile is `SceneGridTile`), SceneCard, ReviewItem, ReviewsBottomSheet (opened only via `ReviewsBottomSheet.show(context)` — ThoughtsScreen and ReviewsFloatingButton share it), ThoughtsEditor, AiReferencesAccordion, JournalContentMoreMenu, and `journal_actions.dart` — a set of shared helper functions (`editJournal`, `shareJournal`, `confirmDeleteJournal`, `deleteJournal`) that encapsulate the domain actions a journal can undergo. Reused by both the more-menu on `JournalContent` and the long-press menu on `JournalCard`. The helpers own the *domain action* (load state / navigate to editor, confirm dialog, Supabase delete + toast, navigate to `TicketPosterPickerScreen`) but intentionally leave post-action navigation (e.g. popping after delete) to the caller, since that depends on which screen initiated the action.
 
 - **movie/** - Movie data management with repository pattern
   - `controllers/` - MovieDetailController, MovieImagesController, SearchMovieController
@@ -102,7 +102,7 @@ The app follows a feature-based architecture where each feature is self-containe
   - `widgets/` - FlippableTicket (3D flip animation), TicketFront (poster side), TicketBack (details side), FilmStripClipper (perforation CustomClipper)
 
 - **login/** - Authentication screens and user creation flows
-  - `screens/` - LoginScreen, CreateUserScreen (username input with validation: alphanumeric/underscore/dot only, uniqueness check via the `username_available` RPC, error toasts use `ToastGravity.TOP` to stay visible above the keyboard). `validateUsername()` is a top-level function for testability.
+  - `screens/` - LoginScreen, CreateUserScreen (username input with validation: alphanumeric/underscore/dot only, uniqueness check via the `username_available` RPC, error toasts use `CustomToast.showError(..., gravity: ToastGravity.TOP)` to stay visible above the keyboard). `validateUsername()` is a top-level function for testability.
 
 - **onboarding/** - Branded splash shown on cold start when the user is unauthenticated
   - `screens/` - BrandingSplashScreen — fade-in/hold/fade-out timeline (3s total) via a single `AnimationController` + `TweenSequence` (mirrors `journal_complete.dart`'s pattern). When the fade controller hits `completed`, calls `splashShownProvider.markShown()` so `HomeScreen` re-renders to `LoginScreen`. **No `Navigator.push`** — the splash plugs into `HomeScreen`'s stream-driven conditional in `home.dart` (the `splashShown ? LoginScreen : BrandingSplashScreen` branch), gated by `splashShownProvider`.
@@ -118,7 +118,7 @@ The app follows a feature-based architecture where each feature is self-containe
   - `screens/` - SettingsScreen (displays username, sign out, delete account options). Logout and delete flows invalidate journal/username providers to prevent stale data on re-login. When `needsAccountLinkProvider` is true it grows a warning-colored **Secure Account** item (the only entry point once the one-time prompt is gone) and the Logout dialog swaps in copy saying that getting back in depends on this device. Deliberately *not* "you will lose everything" — logging out is recoverable; see the `supabase-migration` skill.
 
 - **toast/** - Toast notification utilities
-  - `custom_toast.dart` - Custom toast built on `fluttertoast`. Three static entry points — `showSuccess(context, msg)`, `showError(msg)`, `showWarning(msg)` — all render the same dark bordered card via a private `_show({icon, statusColor, message})`; only the icon glyph + accent vary. The icon is a filled circle in the status color with a **plain black** inner glyph. Colors come from `StatusColors` in `themes.dart` (success = primary `#A8DADD`, error `#FF615D`, warning `#FF9F1C`) — the single source of truth. `showSuccess` keeps a `context` param for call-site compatibility but no longer uses it for styling. Call `CustomToast.init(context)` once before showing (idiom: init immediately before the show call). Status→color mapping pinned by `custom_toast_test.dart`.
+  - `custom_toast.dart` - Custom toast built on `fluttertoast`. Three static entry points — `showSuccess(context, msg)`, `showError(context, msg, {gravity})`, `showWarning(context, msg)` — all render the same dark bordered card via a private `_show(...)`; only the icon glyph + accent vary. The icon is a filled circle in the status color with a **plain black** inner glyph. Colors come from `StatusColors` in `themes.dart` (success = primary `#A8DADD`, error `#FF615D`, warning `#FF9F1C`) — the single source of truth. There is no `init` step: `_show` re-inits its `FToast` from the passed context on every call (the old `CustomToast.init(context)` + show pairing is gone). `showError` takes an optional `gravity` (default `ToastGravity.BOTTOM`; the enum is re-exported from `custom_toast.dart` so call sites don't import fluttertoast) — CreateUserScreen passes `ToastGravity.TOP` to stay above the keyboard. This is the app's only error surface: no raw `Fluttertoast` or `SnackBar` calls. Status→color mapping pinned by `custom_toast_test.dart`.
 
 ### Core Infrastructure
 
@@ -126,12 +126,15 @@ The app follows a feature-based architecture where each feature is self-containe
 - `network/` - Dio HTTP clients for external APIs
   - `tmdb_dio_client.dart` - The Movie Database API client
   - `quesgen_dio_client.dart` - AI review generation API client
+- `utils/` - Shared utility functions
+  - `tmdb_image_url.dart` - `tmdbImageUrl(path, TmdbImageSize)`, the one place TMDB image URLs are built (sizes: w154/w342/w500/w780/original; tolerates a missing leading slash). All widgets use it; the only remaining literal base URL is `splash_posters.dart`'s const fallback list. Phase 5 will hang `cacheWidth` guidance off this helper.
 
 **lib/shared_widgets/**
 - Reusable UI components used across features
 - `confirmation_dialog.dart` - Generic confirmation dialog widget
 - `circled_icon_button.dart` - Circular icon button with border styling, used for back buttons and action buttons across screens
   - Props: `icon` (required), `onPressed` (required), `iconSize` (default: 16), `iconColor`, `borderColor`, `outerPadding`, `size` (default: 36)
+- `sheet_app_bar.dart` - `SheetAppBar({title?, onCancel, onDone, backgroundColor?})`, the Cancel / centered-title / Done app bar shared by ThoughtsScreen, ScenesSelectSheet, and CaptionEditor (which passes no title). Implements `PreferredSizeWidget`.
 - `provider_sign_in_button.dart` - `ProviderSignInButton`, the outlined Apple/Google button. Extracted from `login.dart`'s private `_SignInButton` when `SecureAccountSheet` needed the same control: both flows ask for the same credential through the same native prompt, so they must look identical. Only the label differs ("Sign in with…" vs "Continue with…").
 
 **Root-level managers:**
@@ -263,7 +266,7 @@ feature_name/
 - Supports light and dark themes (default: dark mode)
 - Theme definitions in `lib/themes.dart`
 - Access colors via `Theme.of(context).colorScheme`
-- **Status colors**: `StatusColors` (in `themes.dart`) holds `success` (= primary `#A8DADD`), `error` (`#FF615D`), `warning` (`#FF9F1C`) as context-free constants — used as icon backgrounds (e.g. toasts), with a black inner glyph. They're constants rather than a `ThemeExtension` because consumers like `CustomToast.showError` run without a `BuildContext`.
+- **Status colors**: `StatusColors` (in `themes.dart`) holds `success` (= primary `#A8DADD`), `error` (`#FF615D`), `warning` (`#FF9F1C`) as context-free constants — used as icon backgrounds (e.g. toasts), with a black inner glyph. They're constants rather than a `ThemeExtension` because they're identical in every theme and consumers shouldn't need a `BuildContext` just to pick an accent.
 
 ### Loading States
 - Use **Skeletonizer** package for skeleton screens
@@ -343,7 +346,7 @@ Journals store `Jiffy.toString()`, a **naive local** string with no zone. Postgr
 
 ### Analytics
 - `AnalyticsManager` in `lib/analytics_manager.dart` wraps `FirebaseAnalytics` with static methods. Disabled in debug builds (`!kDebugMode`, set in `main.dart`). All events, screen names, and user properties live there — read the source rather than maintaining a list here.
-- **Screen tracking pattern**: stateful screens call `logScreenView()` in `initState`; ConsumerWidget screens wrap in the `ScreenViewTracker` widget.
+- **Screen tracking pattern**: one idiom — every screen wraps its built root in the `ScreenViewTracker` widget (no `logScreenView()`-in-`initState` variant anymore). Screens with early loading/error returns (e.g. `JournalContent`) wrap only the main state so transient frames aren't logged. `ThoughtsScreen` deliberately does **not** log a screen view — it is a section of the Journaling flow, and logging it inflated screen counts.
 - **User identification**: `ref.listenManual` on auth/username providers in `MyApp` sets user id + `sign_in_method` / `username` properties.
 - **iOS config**: `IS_ANALYTICS_ENABLED: true` in `GoogleService-Info.plist`.
 
@@ -414,7 +417,7 @@ State lives in `lib/features/journal/controllers/`: `JournalState` (single) and 
 - **Caption editor focus management**: `caption_editor.dart` owns `_captionFocusNodes` keyed by scene path. A `postFrameCallback` in `initState` focuses the initial scene's `TextField`; `_onPageChanged` re-focuses on every swipe so the keyboard stays up as the user captions multiple scenes.
 - **Journal actions**: `lib/features/journal/widgets/journal_actions.dart` holds `editJournal` / `shareJournal` / `confirmDeleteJournal` / `deleteJournal`. Reused by both `JournalContent`'s more-menu and `JournalCard`'s context menu. Helpers own the domain action but leave post-action navigation to the caller.
 - **`ReviewItem`** has four visual states via `showAction` / `isSelected` / `transparent` props — used in reviews bottom sheet (add/selected), AI references accordion (transparent, no action), etc.
-- **Selection-limit UX (scenes & emotions share one pattern)**: both `ScenesSelectSheet` (cap `_maxSceneLimit = 10`) and `EmotionsSelectorBottomSheet` (`maxSelectionLimit = 3`) show the same limit text — `'Select up to N (M/N)'`, styled `AvenirNext / 14 / w500 / height 1.5 / Colors.white.withAlpha(153)`, no color change at the cap. In `ScenesSelectSheet` this count is a **fixed header** above an `Expanded(SingleChildScrollView(GridView))` so it stays visible while the grid scrolls (don't move it back inside the scroll view). Tapping an *unselected* item while already at the cap is blocked **and** shows `CustomToast.showError('You can select up to N scenes/emotions')` (preceded by `CustomToast.init(context)`, per the `journal_actions.dart` idiom); deselect/re-select stay silent. **Testing gotcha**: the toast spawns chained `fluttertoast` timers (≈2s show + fade), so any widget test that triggers an over-cap tap must drain them with `await tester.pump(const Duration(seconds: 3)); await tester.pumpAndSettle();` or it fails with "Timer still pending" (see `scenes_select_sheet_test.dart` / `emotions_selector_bottom_sheet_test.dart`).
+- **Selection-limit UX (scenes & emotions share one pattern)**: both `ScenesSelectSheet` (cap `_maxSceneLimit = 10`) and `EmotionsSelectorBottomSheet` (`maxSelectionLimit = 3`) show the same limit text — `'Select up to N (M/N)'`, styled `AvenirNext / 14 / w500 / height 1.5 / Colors.white.withAlpha(153)`, no color change at the cap. In `ScenesSelectSheet` this count is a **fixed header** above an `Expanded(SingleChildScrollView(GridView))` so it stays visible while the grid scrolls (don't move it back inside the scroll view). Tapping an *unselected* item while already at the cap is blocked **and** shows `CustomToast.showError(context, 'You can select up to N scenes/emotions')`; deselect/re-select stay silent. **Testing gotcha**: the toast spawns chained `fluttertoast` timers (≈2s show + fade), so any widget test that triggers an over-cap tap must drain them with `await tester.pump(const Duration(seconds: 3)); await tester.pumpAndSettle();` or it fails with "Timer still pending" (see `scenes_select_sheet_test.dart` / `emotions_selector_bottom_sheet_test.dart`).
 
 ### Working with Share Ticket
 Feature lives under `lib/features/share/`. Flow: callers → `TicketPosterPickerScreen` → `ShareTicketScreen`.

--- a/lib/core/utils/tmdb_image_url.dart
+++ b/lib/core/utils/tmdb_image_url.dart
@@ -1,0 +1,13 @@
+/// The TMDB image widths the app actually uses — a subset of the sizes the
+/// TMDB configuration endpoint offers.
+enum TmdbImageSize { w154, w342, w500, w780, original }
+
+/// Builds a TMDB image URL from a TMDB `poster_path` / `backdrop_path` /
+/// `file_path` value and a size bucket.
+///
+/// TMDB paths come with a leading slash; a missing one is tolerated so call
+/// sites never produce a `w154//x.jpg`-style double slash.
+String tmdbImageUrl(String path, TmdbImageSize size) {
+  final slash = path.startsWith('/') ? '' : '/';
+  return 'https://image.tmdb.org/t/p/${size.name}$slash$path';
+}

--- a/lib/features/account_link/widgets/secure_account_sheet.dart
+++ b/lib/features/account_link/widgets/secure_account_sheet.dart
@@ -58,9 +58,10 @@ class _SecureAccountSheetState extends ConsumerState<SecureAccountSheet> {
 
     try {
       final service = ref.read(accountLinkServiceProvider);
-      final outcome = method == 'apple'
-          ? await service.linkApple()
-          : await service.linkGoogle();
+      final outcome =
+          method == 'apple'
+              ? await service.linkApple()
+              : await service.linkGoogle();
       if (!mounted) return;
 
       switch (outcome) {
@@ -68,8 +69,7 @@ class _SecureAccountSheetState extends ConsumerState<SecureAccountSheet> {
           unawaited(AnalyticsManager.logAccountLinked(method: method));
           // Toast before popping: FToast resolves its overlay from the context
           // it is handed, and this one is about to be torn down.
-          CustomToast.init(context);
-          CustomToast.showSuccess('Account secured');
+          CustomToast.showSuccess(context, 'Account secured');
           Navigator.of(context).pop();
         case IdentityLinkOutcome.cancelled:
           // They backed out of the system prompt. Leave the sheet open — that
@@ -82,8 +82,10 @@ class _SecureAccountSheetState extends ConsumerState<SecureAccountSheet> {
       }
     } catch (e) {
       if (!mounted) return;
-      CustomToast.init(context);
-      CustomToast.showError("Couldn't secure your account. Please try again.");
+      CustomToast.showError(
+        context,
+        "Couldn't secure your account. Please try again.",
+      );
     } finally {
       if (mounted) setState(() => _isLinking = false);
     }
@@ -151,9 +153,8 @@ class _SecureAccountSheetState extends ConsumerState<SecureAccountSheet> {
             const SizedBox(height: 8),
             Center(
               child: TextButton(
-                onPressed: _isLinking
-                    ? null
-                    : () => Navigator.of(context).pop(),
+                onPressed:
+                    _isLinking ? null : () => Navigator.of(context).pop(),
                 child: Text(
                   'Not now',
                   style: TextStyle(

--- a/lib/features/home/widgets/journal_card.dart
+++ b/lib/features/home/widgets/journal_card.dart
@@ -5,6 +5,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:movie_journal/features/journal/controllers/journal.dart';
 import 'package:movie_journal/features/journal/screens/journal_content.dart';
 import 'package:movie_journal/features/journal/widgets/journal_actions.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 
 class JournalCard extends ConsumerStatefulWidget {
   final JournalState journal;
@@ -121,7 +122,7 @@ class _JournalCardVisual extends StatelessWidget {
                 child: AspectRatio(
                   aspectRatio: 150 / 215,
                   child: Image.network(
-                    'https://image.tmdb.org/t/p/w342${journal.moviePoster}',
+                    tmdbImageUrl(journal.moviePoster, TmdbImageSize.w342),
                     fit: BoxFit.cover,
                     alignment: Alignment.center,
                   ),

--- a/lib/features/journal/screens/caption_editor.dart
+++ b/lib/features/journal/screens/caption_editor.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:movie_journal/analytics_manager.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 import 'package:movie_journal/features/journal/controllers/journal.dart';
 import 'package:movie_journal/features/journal/widgets/scene_card.dart';
-import 'package:movie_journal/shared_widgets/action_text_button.dart';
+import 'package:movie_journal/shared_widgets/sheet_app_bar.dart';
 
 class CaptionEditor extends ConsumerStatefulWidget {
   final int initialSceneIndex;
@@ -23,7 +24,6 @@ class _CaptionEditorState extends ConsumerState<CaptionEditor> {
   @override
   void initState() {
     super.initState();
-    AnalyticsManager.logScreenView('CaptionEditor');
     _currentPage = widget.initialSceneIndex;
     _pageController = PageController(initialPage: widget.initialSceneIndex);
 
@@ -67,7 +67,7 @@ class _CaptionEditorState extends ConsumerState<CaptionEditor> {
     var selectedScenes = ref.read(journalControllerProvider).selectedScenes;
     for (var scene in selectedScenes) {
       precacheImage(
-        NetworkImage('https://image.tmdb.org/t/p/w500${scene.path}'),
+        NetworkImage(tmdbImageUrl(scene.path, TmdbImageSize.w500)),
         context,
       );
     }
@@ -103,103 +103,95 @@ class _CaptionEditorState extends ConsumerState<CaptionEditor> {
   Widget build(BuildContext context) {
     final selectedScenes = ref.watch(journalControllerProvider).selectedScenes;
 
-    return SizedBox(
-      height: MediaQuery.of(context).size.height,
-      child: Scaffold(
-        backgroundColor: Colors.black,
-        appBar: AppBar(
+    return ScreenViewTracker(
+      screenName: 'CaptionEditor',
+      child: SizedBox(
+        height: MediaQuery.of(context).size.height,
+        child: Scaffold(
           backgroundColor: Colors.black,
-          elevation: 0,
-          automaticallyImplyLeading: false,
-          titleSpacing: 0,
-          title: ActionTextButton(
-            text: 'Cancel',
-            color: Colors.white,
-            onPressed: () {
-              Navigator.pop(context);
-            },
+          appBar: SheetAppBar(
+            backgroundColor: Colors.black,
+            onCancel: () => Navigator.pop(context),
+            onDone: _saveAllCaptions,
           ),
-          actions: [
-            ActionTextButton(text: 'Done', onPressed: _saveAllCaptions),
-          ],
-        ),
-        body: Column(
-          children: [
-            const SizedBox(height: 55),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 0),
-              child: SizedBox(
-                height: 295,
-                child: PageView.builder(
-                  controller: _pageController,
-                  onPageChanged: _onPageChanged,
-                  itemCount: selectedScenes.length,
-                  itemBuilder: (context, index) {
-                    final scene = selectedScenes[index];
-                    final controller = _captionControllers[scene.path];
-                    final focusNode = _captionFocusNodes[scene.path];
+          body: Column(
+            children: [
+              const SizedBox(height: 55),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 0),
+                child: SizedBox(
+                  height: 295,
+                  child: PageView.builder(
+                    controller: _pageController,
+                    onPageChanged: _onPageChanged,
+                    itemCount: selectedScenes.length,
+                    itemBuilder: (context, index) {
+                      final scene = selectedScenes[index];
+                      final controller = _captionControllers[scene.path];
+                      final focusNode = _captionFocusNodes[scene.path];
 
-                    return SingleChildScrollView(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: SceneCard(
-                          imagePath: scene.path,
-                          controller: controller,
-                          focusNode: focusNode,
-                          isEditable: true,
+                      return SingleChildScrollView(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: SceneCard(
+                            imagePath: scene.path,
+                            controller: controller,
+                            focusNode: focusNode,
+                            isEditable: true,
+                          ),
                         ),
-                      ),
-                    );
-                  },
+                      );
+                    },
+                  ),
                 ),
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: SizedBox(
-                width: double.infinity,
-                height: 24,
-                child: Stack(
-                  alignment: Alignment.center,
-                  children: [
-                    // Centered dots
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      spacing: 4,
-                      children: List.generate(
-                        selectedScenes.length,
-                        (index) => Container(
-                          width: 6,
-                          height: 6,
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color:
-                                index == _currentPage
-                                    ? Colors.white
-                                    : Colors.white.withAlpha(77),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: SizedBox(
+                  width: double.infinity,
+                  height: 24,
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      // Centered dots
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        spacing: 4,
+                        children: List.generate(
+                          selectedScenes.length,
+                          (index) => Container(
+                            width: 6,
+                            height: 6,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color:
+                                  index == _currentPage
+                                      ? Colors.white
+                                      : Colors.white.withAlpha(77),
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                    // Text positioned on the right
-                    Positioned(
-                      right: 0,
-                      child: Text(
-                        '${_currentPage + 1} of ${selectedScenes.length}',
-                        style: TextStyle(
-                          color: Colors.white.withAlpha(153),
-                          fontSize: 13,
-                          fontWeight: FontWeight.w500,
-                          fontFamily: 'AvenirNext',
-                          height: 1.5,
+                      // Text positioned on the right
+                      Positioned(
+                        right: 0,
+                        child: Text(
+                          '${_currentPage + 1} of ${selectedScenes.length}',
+                          style: TextStyle(
+                            color: Colors.white.withAlpha(153),
+                            fontSize: 13,
+                            fontWeight: FontWeight.w500,
+                            fontFamily: 'AvenirNext',
+                            height: 1.5,
+                          ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/journal/screens/journal_complete.dart
+++ b/lib/features/journal/screens/journal_complete.dart
@@ -30,7 +30,6 @@ class _JournalCompleteScreenState extends State<JournalCompleteScreen>
   @override
   void initState() {
     super.initState();
-    AnalyticsManager.logScreenView('JournalComplete');
     _controller = AnimationController(
       duration: const Duration(milliseconds: 1200),
       vsync: this,
@@ -90,155 +89,163 @@ class _JournalCompleteScreenState extends State<JournalCompleteScreen>
   Widget build(BuildContext context) {
     final primaryColor = Theme.of(context).colorScheme.primary;
 
-    return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.surface,
-      body: SafeArea(
-        child: Stack(
-          children: [
-            // Close (X): this screen only appears for a just-saved journal,
-            // so close mirrors the `journalComplete` share-flow close target —
-            // pop everything down to Home.
-            Align(
-              alignment: Alignment.topRight,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 8, top: 4),
-                child: IconButton(
-                  onPressed:
-                      () => Navigator.of(
-                        context,
-                      ).popUntil((route) => route.isFirst),
-                  icon: const Icon(Icons.close, color: Colors.white, size: 24),
+    return ScreenViewTracker(
+      screenName: 'JournalComplete',
+      child: Scaffold(
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        body: SafeArea(
+          child: Stack(
+            children: [
+              // Close (X): this screen only appears for a just-saved journal,
+              // so close mirrors the `journalComplete` share-flow close target —
+              // pop everything down to Home.
+              Align(
+                alignment: Alignment.topRight,
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 8, top: 4),
+                  child: IconButton(
+                    onPressed:
+                        () => Navigator.of(
+                          context,
+                        ).popUntil((route) => route.isFirst),
+                    icon: const Icon(
+                      Icons.close,
+                      color: Colors.white,
+                      size: 24,
+                    ),
+                  ),
                 ),
               ),
-            ),
-            Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  // Checkmark icon
-                  ScaleTransition(
-                    scale: _checkScale,
-                    child: FadeTransition(
-                      opacity: _checkFade,
-                      child: Container(
-                        width: 36,
-                        height: 36,
-                        decoration: const BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: Colors.white,
-                        ),
-                        child: const Icon(
-                          Icons.check,
-                          color: Colors.black,
-                          size: 20,
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-
-                  // Title text
-                  SlideTransition(
-                    position: _textSlide,
-                    child: FadeTransition(
-                      opacity: _textFade,
-                      child: Text(
-                        "You've saved a journal",
-                        style: GoogleFonts.inter(
-                          fontSize: 20,
-                          fontWeight: FontWeight.w600,
-                          color: Colors.white,
+              Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    // Checkmark icon
+                    ScaleTransition(
+                      scale: _checkScale,
+                      child: FadeTransition(
+                        opacity: _checkFade,
+                        child: Container(
+                          width: 36,
+                          height: 36,
+                          decoration: const BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: Colors.white,
+                          ),
+                          child: const Icon(
+                            Icons.check,
+                            color: Colors.black,
+                            size: 20,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                  const SizedBox(height: 32),
+                    const SizedBox(height: 16),
 
-                  // Journal card (reused from home)
-                  ScaleTransition(
-                    scale: _cardScale,
-                    child: FadeTransition(
-                      opacity: _cardFade,
-                      child: SizedBox(
-                        width: 200,
-                        child: IgnorePointer(
-                          child: JournalCard(journal: widget.journal),
+                    // Title text
+                    SlideTransition(
+                      position: _textSlide,
+                      child: FadeTransition(
+                        opacity: _textFade,
+                        child: Text(
+                          "You've saved a journal",
+                          style: GoogleFonts.inter(
+                            fontSize: 20,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.white,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                  const SizedBox(height: 40),
+                    const SizedBox(height: 32),
 
-                  // Share Ticket button
-                  FadeTransition(
-                    opacity: _buttonsFade,
-                    child: ElevatedButton(
-                      onPressed: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            settings: const RouteSettings(
-                              name: kShareFlowRouteName,
+                    // Journal card (reused from home)
+                    ScaleTransition(
+                      scale: _cardScale,
+                      child: FadeTransition(
+                        opacity: _cardFade,
+                        child: SizedBox(
+                          width: 200,
+                          child: IgnorePointer(
+                            child: JournalCard(journal: widget.journal),
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 40),
+
+                    // Share Ticket button
+                    FadeTransition(
+                      opacity: _buttonsFade,
+                      child: ElevatedButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              settings: const RouteSettings(
+                                name: kShareFlowRouteName,
+                              ),
+                              builder:
+                                  (context) => TicketPosterPickerScreen(
+                                    journal: widget.journal,
+                                    entry: ShareTicketEntry.journalComplete,
+                                  ),
                             ),
-                            builder:
-                                (context) => TicketPosterPickerScreen(
-                                  journal: widget.journal,
-                                  entry: ShareTicketEntry.journalComplete,
-                                ),
+                          );
+                        },
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: primaryColor,
+                          foregroundColor: Colors.black,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 12,
                           ),
-                        );
-                      },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: primaryColor,
-                        foregroundColor: Colors.black,
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 12,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          textStyle: const TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            fontFamily: 'AvenirNext',
+                          ),
                         ),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        textStyle: const TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w600,
-                          fontFamily: 'AvenirNext',
-                        ),
+                        child: const Text('Share Ticket'),
                       ),
-                      child: const Text('Share Ticket'),
                     ),
-                  ),
-                  const SizedBox(height: 4),
+                    const SizedBox(height: 4),
 
-                  // View Journal button
-                  FadeTransition(
-                    opacity: _buttonsFade,
-                    child: TextButton(
-                      onPressed: () {
-                        Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(
-                            builder:
-                                (context) => JournalContent(
-                                  journalId: widget.journal.id,
-                                ),
+                    // View Journal button
+                    FadeTransition(
+                      opacity: _buttonsFade,
+                      child: TextButton(
+                        onPressed: () {
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(
+                              builder:
+                                  (context) => JournalContent(
+                                    journalId: widget.journal.id,
+                                  ),
+                            ),
+                          );
+                        },
+                        style: TextButton.styleFrom(
+                          foregroundColor:
+                              Theme.of(context).colorScheme.primary,
+                          textStyle: const TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            fontFamily: 'AvenirNext',
                           ),
-                        );
-                      },
-                      style: TextButton.styleFrom(
-                        foregroundColor: Theme.of(context).colorScheme.primary,
-                        textStyle: const TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w600,
-                          fontFamily: 'AvenirNext',
                         ),
+                        child: const Text('View Journal'),
                       ),
-                      child: const Text('View Journal'),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/journal/screens/journal_content.dart
+++ b/lib/features/journal/screens/journal_content.dart
@@ -26,7 +26,6 @@ class _JournalContentState extends ConsumerState<JournalContent> {
   @override
   void initState() {
     super.initState();
-    AnalyticsManager.logScreenView('JournalContent');
     _pageController = PageController();
   }
 
@@ -74,164 +73,167 @@ class _JournalContentState extends ConsumerState<JournalContent> {
 
     final journal = journals[journalIndex];
 
-    return Scaffold(
-      body: CustomScrollView(
-        slivers: [
-          SliverAppBar(
-            backgroundColor: Theme.of(context).colorScheme.surface,
-            pinned: true,
-            floating: true,
-            snap: true,
-            automaticallyImplyLeading: false,
-            centerTitle: true,
-            actions: [
-              IconButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      settings: const RouteSettings(
-                        name: kShareFlowRouteName,
+    return ScreenViewTracker(
+      screenName: 'JournalContent',
+      child: Scaffold(
+        body: CustomScrollView(
+          slivers: [
+            SliverAppBar(
+              backgroundColor: Theme.of(context).colorScheme.surface,
+              pinned: true,
+              floating: true,
+              snap: true,
+              automaticallyImplyLeading: false,
+              centerTitle: true,
+              actions: [
+                IconButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        settings: const RouteSettings(
+                          name: kShareFlowRouteName,
+                        ),
+                        builder: (_) => TicketPosterPickerScreen(
+                          journal: journal,
+                          entry: ShareTicketEntry.journalContent,
+                        ),
                       ),
-                      builder: (_) => TicketPosterPickerScreen(
-                        journal: journal,
-                        entry: ShareTicketEntry.journalContent,
-                      ),
-                    ),
-                  );
-                },
-                icon: const Icon(Icons.ios_share, color: Colors.white),
+                    );
+                  },
+                  icon: const Icon(Icons.ios_share, color: Colors.white),
+                ),
+                JournalContentMoreMenu(journalId: widget.journalId),
+              ],
+              leading: CircledIconButton(
+                icon: Icons.arrow_back_ios_new,
+                onPressed: () => Navigator.pop(context),
+                outerPadding: const EdgeInsets.only(left: 16),
               ),
-              JournalContentMoreMenu(journalId: widget.journalId),
-            ],
-            leading: CircledIconButton(
-              icon: Icons.arrow_back_ios_new,
-              onPressed: () => Navigator.pop(context),
-              outerPadding: const EdgeInsets.only(left: 16),
+              leadingWidth: 40 + 16,
             ),
-            leadingWidth: 40 + 16,
-          ),
 
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      journal.movieTitle,
-                      style: GoogleFonts.inter(fontSize: 32),
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      journal.updatedAt.format(pattern: 'MMM do yyyy'),
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w700,
-                        color: Colors.white.withAlpha(178),
-                        fontFamily: 'AvenirNext',
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 24),
-
-                  if (journal.emotions.isNotEmpty)
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: EmotionsSelectorButton(
-                        emotions: journal.emotions,
-                        readonly: true,
+                      child: Text(
+                        journal.movieTitle,
+                        style: GoogleFonts.inter(fontSize: 32),
                       ),
                     ),
-                  if (journal.emotions.isNotEmpty) const SizedBox(height: 24),
-                  journal.selectedScenes.isEmpty
-                      ? const SizedBox.shrink()
-                      : Column(
-                        children: [
-                          SizedBox(
-                            height: 235,
-                            child: PageView.builder(
-                              controller: _pageController,
-                              onPageChanged: _onPageChanged,
-                              itemCount: journal.selectedScenes.length,
-                              itemBuilder: (context, index) {
-                                final scene = journal.selectedScenes[index];
-                                return Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 16,
-                                  ),
-                                  child: SceneCard(
-                                    imagePath: scene.path,
-                                    caption: scene.caption,
-                                    isEditable: false,
-                                  ),
-                                );
-                              },
+                    const SizedBox(height: 8),
+
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Text(
+                        journal.updatedAt.format(pattern: 'MMM do yyyy'),
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white.withAlpha(178),
+                          fontFamily: 'AvenirNext',
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    if (journal.emotions.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: EmotionsSelectorButton(
+                          emotions: journal.emotions,
+                          readonly: true,
+                        ),
+                      ),
+                    if (journal.emotions.isNotEmpty) const SizedBox(height: 24),
+                    journal.selectedScenes.isEmpty
+                        ? const SizedBox.shrink()
+                        : Column(
+                          children: [
+                            SizedBox(
+                              height: 235,
+                              child: PageView.builder(
+                                controller: _pageController,
+                                onPageChanged: _onPageChanged,
+                                itemCount: journal.selectedScenes.length,
+                                itemBuilder: (context, index) {
+                                  final scene = journal.selectedScenes[index];
+                                  return Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 16,
+                                    ),
+                                    child: SceneCard(
+                                      imagePath: scene.path,
+                                      caption: scene.caption,
+                                      isEditable: false,
+                                    ),
+                                  );
+                                },
+                              ),
                             ),
-                          ),
-                          SizedBox(
-                            width: double.infinity,
-                            height: 24,
-                            child: Stack(
-                              alignment: Alignment.center,
-                              children: [
-                                // Centered dots
-                                Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  spacing: 4,
-                                  children: List.generate(
-                                    journal.selectedScenes.length,
-                                    (index) => Container(
-                                      width: 6,
-                                      height: 6,
-                                      decoration: BoxDecoration(
-                                        shape: BoxShape.circle,
-                                        color:
-                                            index == _currentPage
-                                                ? Colors.white
-                                                : Colors.white.withAlpha(77),
+                            SizedBox(
+                              width: double.infinity,
+                              height: 24,
+                              child: Stack(
+                                alignment: Alignment.center,
+                                children: [
+                                  // Centered dots
+                                  Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    spacing: 4,
+                                    children: List.generate(
+                                      journal.selectedScenes.length,
+                                      (index) => Container(
+                                        width: 6,
+                                        height: 6,
+                                        decoration: BoxDecoration(
+                                          shape: BoxShape.circle,
+                                          color:
+                                              index == _currentPage
+                                                  ? Colors.white
+                                                  : Colors.white.withAlpha(77),
+                                        ),
                                       ),
                                     ),
                                   ),
-                                ),
-                              ],
+                                ],
+                              ),
                             ),
-                          ),
-                        ],
-                      ),
-                  const SizedBox(height: 24),
+                          ],
+                        ),
+                    const SizedBox(height: 24),
 
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Text(
-                      journal.thoughts,
-                      style: GoogleFonts.inter(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w500,
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Text(
+                        journal.thoughts,
+                        style: GoogleFonts.inter(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(height: 24),
+                    const SizedBox(height: 24),
 
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child:
-                        journal.selectedRefs.isEmpty
-                            ? const SizedBox.shrink()
-                            : AiReferencesAccordion(
-                              references: journal.selectedRefs,
-                            ),
-                  ),
-                ],
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child:
+                          journal.selectedRefs.isEmpty
+                              ? const SizedBox.shrink()
+                              : AiReferencesAccordion(
+                                references: journal.selectedRefs,
+                              ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/journal/screens/journaling.dart
+++ b/lib/features/journal/screens/journaling.dart
@@ -53,9 +53,7 @@ class _JournalingScreenState extends ConsumerState<JournalingScreen> {
   @override
   void initState() {
     super.initState();
-    AnalyticsManager.logScreenView('Journaling');
     _scrollController.addListener(_onScroll);
-    CustomToast.init(context);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(journalModeProvider.notifier).set(
           _isEditMode ? JournalMode.edit : JournalMode.create);
@@ -116,242 +114,247 @@ class _JournalingScreenState extends ConsumerState<JournalingScreen> {
     final movieAsync = ref.watch(movieDetailControllerProvider);
     final movieId = movieAsync.hasValue ? movieAsync.value!.id : 0;
     final journal = ref.watch(journalControllerProvider);
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, result) async {
-        if (didPop) return;
+    return ScreenViewTracker(
+      screenName: 'Journaling',
+      child: PopScope(
+        canPop: false,
+        onPopInvokedWithResult: (didPop, result) async {
+          if (didPop) return;
 
-        final navigator = Navigator.of(context);
+          final navigator = Navigator.of(context);
 
-        if (!_hasUnsavedChanges()) {
-          navigator.pop();
-          _cleanupState();
-          return;
-        }
+          if (!_hasUnsavedChanges()) {
+            navigator.pop();
+            _cleanupState();
+            return;
+          }
 
-        final shouldDiscard = await showDialog<bool>(
-          context: context,
-          builder: (context) => const _DiscardChangesDialog(),
-        );
+          final shouldDiscard = await showDialog<bool>(
+            context: context,
+            builder: (context) => const _DiscardChangesDialog(),
+          );
 
-        if (shouldDiscard == true) {
-          navigator.pop();
-          _cleanupState();
-        }
-      },
-      child: Scaffold(
-        backgroundColor: Theme.of(context).colorScheme.surface,
-        body: CustomScrollView(
-          controller: _scrollController,
-          slivers: [
-            SliverAppBar(
-              backgroundColor: Theme.of(context).colorScheme.surface,
-              pinned: true,
-              floating: true,
-              snap: true,
-              automaticallyImplyLeading: false,
-              centerTitle: true,
-              title: AnimatedOpacity(
-                opacity: _showTitle ? 1.0 : 0.0,
-                duration: const Duration(milliseconds: 200),
-                child: Text(
-                  widget.movieTitle,
-                  style: GoogleFonts.inter(
-                    fontSize: 18,
-                    fontWeight: FontWeight.w500,
+          if (shouldDiscard == true) {
+            navigator.pop();
+            _cleanupState();
+          }
+        },
+        child: Scaffold(
+          backgroundColor: Theme.of(context).colorScheme.surface,
+          body: CustomScrollView(
+            controller: _scrollController,
+            slivers: [
+              SliverAppBar(
+                backgroundColor: Theme.of(context).colorScheme.surface,
+                pinned: true,
+                floating: true,
+                snap: true,
+                automaticallyImplyLeading: false,
+                centerTitle: true,
+                title: AnimatedOpacity(
+                  opacity: _showTitle ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 200),
+                  child: Text(
+                    widget.movieTitle,
+                    style: GoogleFonts.inter(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
                 ),
-              ),
-              leading: CircledIconButton(
-                onPressed: _handleBackButton,
-                icon: Icons.arrow_back_ios_new,
-                outerPadding: const EdgeInsets.only(left: 16),
-              ),
-              leadingWidth: 40 + 16,
-              actions: [
-                Padding(
-                  padding: const EdgeInsets.only(right: 12),
-                  child: ElevatedButton(
-                    onPressed:
-                        _isSaving ||
-                                (journal.emotions.isEmpty &&
-                                    journal.selectedScenes.isEmpty &&
-                                    journal.thoughts.isEmpty)
-                            ? null
-                            : () async {
-                              setState(() {
-                                _isSaving = true;
-                              });
-                              try {
-                                if (_isEditMode) {
-                                  await ref
-                                      .read(journalControllerProvider.notifier)
-                                      .update();
-                                  if (context.mounted) {
-                                    CustomToast.showSuccess(
-                                      'Your journal has been updated.',
-                                    );
-                                    Navigator.of(context).popUntil(
-                                      (route) => route.isFirst,
-                                    );
-                                  }
-                                } else {
-                                  await ref
-                                      .read(journalControllerProvider.notifier)
-                                      .save();
-                                  final savedJournal =
-                                      ref.read(journalControllerProvider);
-                                  if (context.mounted) {
-                                    unawaited(
-                                      Navigator.pushAndRemoveUntil(
+                leading: CircledIconButton(
+                  onPressed: _handleBackButton,
+                  icon: Icons.arrow_back_ios_new,
+                  outerPadding: const EdgeInsets.only(left: 16),
+                ),
+                leadingWidth: 40 + 16,
+                actions: [
+                  Padding(
+                    padding: const EdgeInsets.only(right: 12),
+                    child: ElevatedButton(
+                      onPressed:
+                          _isSaving ||
+                                  (journal.emotions.isEmpty &&
+                                      journal.selectedScenes.isEmpty &&
+                                      journal.thoughts.isEmpty)
+                              ? null
+                              : () async {
+                                setState(() {
+                                  _isSaving = true;
+                                });
+                                try {
+                                  if (_isEditMode) {
+                                    await ref
+                                        .read(journalControllerProvider.notifier)
+                                        .update();
+                                    if (context.mounted) {
+                                      CustomToast.showSuccess(
                                         context,
-                                        MaterialPageRoute(
-                                          builder:
-                                              (context) =>
-                                                  JournalCompleteScreen(
-                                                    journal: savedJournal,
-                                                  ),
-                                        ),
+                                        'Your journal has been updated.',
+                                      );
+                                      Navigator.of(context).popUntil(
                                         (route) => route.isFirst,
-                                      ),
+                                      );
+                                    }
+                                  } else {
+                                    await ref
+                                        .read(journalControllerProvider.notifier)
+                                        .save();
+                                    final savedJournal =
+                                        ref.read(journalControllerProvider);
+                                    if (context.mounted) {
+                                      unawaited(
+                                        Navigator.pushAndRemoveUntil(
+                                          context,
+                                          MaterialPageRoute(
+                                            builder:
+                                                (context) =>
+                                                    JournalCompleteScreen(
+                                                      journal: savedJournal,
+                                                    ),
+                                          ),
+                                          (route) => route.isFirst,
+                                        ),
+                                      );
+                                    }
+                                  }
+                                  _cleanupState();
+                                } catch (e) {
+                                  if (context.mounted) {
+                                    CustomToast.showError(
+                                      context,
+                                      'Failed to save journal. Please try again.',
                                     );
                                   }
+                                } finally {
+                                  if (mounted) {
+                                    setState(() {
+                                      _isSaving = false;
+                                    });
+                                  }
                                 }
-                                _cleanupState();
-                              } catch (e) {
-                                if (context.mounted) {
-                                  CustomToast.showError(
-                                    'Failed to save journal. Please try again.',
-                                  );
-                                }
-                              } finally {
-                                if (mounted) {
-                                  setState(() {
-                                    _isSaving = false;
-                                  });
-                                }
-                              }
-                            },
-                    style: ButtonStyle(
-                      shape: WidgetStateProperty.all(
-                        RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16),
+                              },
+                      style: ButtonStyle(
+                        shape: WidgetStateProperty.all(
+                          RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
                         ),
-                      ),
-                      padding: WidgetStateProperty.all(
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                      ),
-                      textStyle: WidgetStateProperty.all(
-                        const TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w500,
-                          color: Colors.white,
+                        padding: WidgetStateProperty.all(
+                          const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                         ),
-                      ),
-                      overlayColor: WidgetStateProperty.all(
-                        Theme.of(context).colorScheme.primary,
-                      ),
-                      backgroundColor: WidgetStateProperty.all(
-                        Colors.transparent,
-                      ),
-                      side: WidgetStateProperty.resolveWith((states) {
-                        if (states.contains(WidgetState.disabled)) {
+                        textStyle: WidgetStateProperty.all(
+                          const TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w500,
+                            color: Colors.white,
+                          ),
+                        ),
+                        overlayColor: WidgetStateProperty.all(
+                          Theme.of(context).colorScheme.primary,
+                        ),
+                        backgroundColor: WidgetStateProperty.all(
+                          Colors.transparent,
+                        ),
+                        side: WidgetStateProperty.resolveWith((states) {
+                          if (states.contains(WidgetState.disabled)) {
+                            return BorderSide(
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.primary.withAlpha(76),
+                              width: 1,
+                            );
+                          }
                           return BorderSide(
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.primary.withAlpha(76),
+                            color: Theme.of(context).colorScheme.primary,
                             width: 1,
                           );
-                        }
-                        return BorderSide(
-                          color: Theme.of(context).colorScheme.primary,
-                          width: 1,
-                        );
-                      }),
-                      foregroundColor: WidgetStateProperty.resolveWith((
-                        states,
-                      ) {
-                        if (states.contains(WidgetState.disabled)) {
-                          return Colors.white.withAlpha(76);
-                        }
-                        return Colors.white;
-                      }),
-                    ),
-                    child: _isSaving
-                        ? SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: Center(
-                            child: SizedBox(
-                              width: 14,
-                              height: 14,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: Colors.white,
-                                backgroundColor: Colors.white.withAlpha(50),
+                        }),
+                        foregroundColor: WidgetStateProperty.resolveWith((
+                          states,
+                        ) {
+                          if (states.contains(WidgetState.disabled)) {
+                            return Colors.white.withAlpha(76);
+                          }
+                          return Colors.white;
+                        }),
+                      ),
+                      child: _isSaving
+                          ? SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: Center(
+                              child: SizedBox(
+                                width: 14,
+                                height: 14,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                  backgroundColor: Colors.white.withAlpha(50),
+                                ),
                               ),
                             ),
-                          ),
-                        )
-                        : const Text('Save'),
+                          )
+                          : const Text('Save'),
+                    ),
+                  ),
+                ],
+              ),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    children: [
+                      SizedBox(
+                        width: double.infinity,
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          spacing: 8,
+                          children: [
+                            Text(
+                              widget.movieTitle,
+                              style: GoogleFonts.inter(
+                                fontSize: 28,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                            Text(
+                              _isEditMode
+                                  ? journal.createdAt.format(pattern: 'MMM do yyyy')
+                                  : Jiffy.now().format(pattern: 'MMM do yyyy'),
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.white.withAlpha(179),
+                                fontFamily: 'AvenirNext',
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 36),
+                      EmotionsSelectorButton(
+                        emotions: journal.emotions,
+                        onSave: (selectedEmotions) {
+                          ref
+                              .read(journalControllerProvider.notifier)
+                              .setEmotions(selectedEmotions);
+                        },
+                      ),
+                      const SizedBox(height: 36),
+
+                      ScenesSelector(movieId: movieId),
+                      const SectionSeperator(),
+                      const ThoughtsEditor(),
+                    ],
                   ),
                 ),
-              ],
-            ),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  children: [
-                    SizedBox(
-                      width: double.infinity,
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        spacing: 8,
-                        children: [
-                          Text(
-                            widget.movieTitle,
-                            style: GoogleFonts.inter(
-                              fontSize: 28,
-                              fontWeight: FontWeight.w500,
-                            ),
-                          ),
-                          Text(
-                            _isEditMode
-                                ? journal.createdAt.format(pattern: 'MMM do yyyy')
-                                : Jiffy.now().format(pattern: 'MMM do yyyy'),
-                            style: TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold,
-                              color: Colors.white.withAlpha(179),
-                              fontFamily: 'AvenirNext',
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 36),
-                    EmotionsSelectorButton(
-                      emotions: journal.emotions,
-                      onSave: (selectedEmotions) {
-                        ref
-                            .read(journalControllerProvider.notifier)
-                            .setEmotions(selectedEmotions);
-                      },
-                    ),
-                    const SizedBox(height: 36),
-
-                    ScenesSelector(movieId: movieId),
-                    const SectionSeperator(),
-                    const ThoughtsEditor(),
-                  ],
-                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/journal/screens/movie_preview.dart
+++ b/lib/features/journal/screens/movie_preview.dart
@@ -5,6 +5,7 @@ import 'package:movie_journal/features/journal/controllers/journal.dart';
 import 'package:movie_journal/features/journal/screens/journaling.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
 import 'package:skeletonizer/skeletonizer.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 
 class MoviePreviewScreen extends ConsumerWidget {
   final int movieId;
@@ -39,7 +40,10 @@ class MoviePreviewScreen extends ConsumerWidget {
                                   child: ClipRRect(
                                     borderRadius: BorderRadius.circular(12),
                                     child: Image.network(
-                                      'https://image.tmdb.org/t/p/original${movie.posterPath}',
+                                      tmdbImageUrl(
+                                        movie.posterPath!,
+                                        TmdbImageSize.original,
+                                      ),
                                       fit: BoxFit.cover,
                                       width: double.infinity,
                                       frameBuilder: (

--- a/lib/features/journal/screens/thoughts.dart
+++ b/lib/features/journal/screens/thoughts.dart
@@ -4,10 +4,9 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:movie_journal/features/journal/controllers/journal.dart';
 import 'package:movie_journal/features/quesgen/review.dart';
 import 'package:movie_journal/features/journal/widgets/review_item.dart';
-import 'package:movie_journal/analytics_manager.dart';
 import 'package:movie_journal/features/journal/widgets/reviews_bottom_sheet.dart';
 import 'package:movie_journal/features/journal/widgets/reviews_floating_button.dart';
-import 'package:movie_journal/shared_widgets/action_text_button.dart';
+import 'package:movie_journal/shared_widgets/sheet_app_bar.dart';
 
 class ThoughtsScreen extends ConsumerStatefulWidget {
   const ThoughtsScreen({super.key});
@@ -26,7 +25,8 @@ class _ThoughtsScreenState extends ConsumerState<ThoughtsScreen> {
   @override
   void initState() {
     super.initState();
-    AnalyticsManager.logScreenView('Thoughts');
+    // Deliberately NOT logged as a screen view: this is a section of the
+    // Journaling flow, and logging it inflated screen counts in GA.
     thoughtsController.text = ref.read(journalControllerProvider).thoughts;
     thoughtsController.addListener(_onTextChanged);
   }
@@ -101,15 +101,7 @@ class _ThoughtsScreenState extends ConsumerState<ThoughtsScreen> {
     textPainter.dispose();
   }
 
-  void _openReviewsBottomSheet() {
-    showModalBottomSheet(
-      useSafeArea: true,
-      isScrollControlled: true,
-      context: context,
-      backgroundColor: const Color(0xFF171717),
-      builder: (context) => const Wrap(children: [ReviewsBottomSheet()]),
-    );
-  }
+  void _openReviewsBottomSheet() => ReviewsBottomSheet.show(context);
 
   Widget _buildSelectedReviewsSection(
     List<Review> references, {
@@ -172,40 +164,15 @@ class _ThoughtsScreenState extends ConsumerState<ThoughtsScreen> {
         ref.watch(journalControllerProvider).selectedRefs;
     final isEditMode = ref.watch(journalModeProvider) == JournalMode.edit;
     return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false,
-        titleSpacing: 0,
-        centerTitle: true,
-        title: Row(
-          children: [
-            ActionTextButton(
-              text: 'Cancel',
-              color: Colors.white,
-              onPressed: () {
-                Navigator.pop(context);
-              },
-            ),
-            const Expanded(
-              child: Center(
-                child: Text(
-                  'Thoughts',
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
-                ),
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          ActionTextButton(
-            text: 'Done',
-            onPressed: () {
-              ref
-                  .read(journalControllerProvider.notifier)
-                  .setThoughts(thoughtsController.text);
-              Navigator.pop(context);
-            },
-          ),
-        ],
+      appBar: SheetAppBar(
+        title: 'Thoughts',
+        onCancel: () => Navigator.pop(context),
+        onDone: () {
+          ref
+              .read(journalControllerProvider.notifier)
+              .setThoughts(thoughtsController.text);
+          Navigator.pop(context);
+        },
       ),
       body: Column(
         children: [

--- a/lib/features/journal/widgets/emotions_selector_bottom_sheet.dart
+++ b/lib/features/journal/widgets/emotions_selector_bottom_sheet.dart
@@ -264,8 +264,8 @@ class _EmotionsSelectorBottomSheetState
     // Block (with feedback) when trying to exceed the cap.
     if (!isSelected &&
         _tempSelectedEmotions.length >= widget.maxSelectionLimit) {
-      CustomToast.init(context);
       CustomToast.showError(
+        context,
         'You can select up to ${widget.maxSelectionLimit} emotions',
       );
       return;

--- a/lib/features/journal/widgets/journal_actions.dart
+++ b/lib/features/journal/widgets/journal_actions.dart
@@ -21,11 +21,12 @@ void editJournal(BuildContext context, WidgetRef ref, JournalState journal) {
   Navigator.push(
     context,
     MaterialPageRoute(
-      builder: (context) => JournalingScreen(
-        movieTitle: journal.movieTitle,
-        moviePosterUrl: journal.moviePoster,
-        editJournalId: journal.id,
-      ),
+      builder:
+          (context) => JournalingScreen(
+            movieTitle: journal.movieTitle,
+            moviePosterUrl: journal.moviePoster,
+            editJournalId: journal.id,
+          ),
     ),
   );
 }
@@ -34,10 +35,11 @@ void shareJournal(BuildContext context, JournalState journal) {
   Navigator.of(context).push(
     MaterialPageRoute(
       settings: const RouteSettings(name: kShareFlowRouteName),
-      builder: (_) => TicketPosterPickerScreen(
-        journal: journal,
-        entry: ShareTicketEntry.journalContent,
-      ),
+      builder:
+          (_) => TicketPosterPickerScreen(
+            journal: journal,
+            entry: ShareTicketEntry.journalContent,
+          ),
     ),
   );
 }
@@ -45,14 +47,15 @@ void shareJournal(BuildContext context, JournalState journal) {
 Future<bool> confirmDeleteJournal(BuildContext context) async {
   final shouldDelete = await showDialog<bool>(
     context: context,
-    builder: (context) => ConfirmationDialog(
-      title: 'Delete Journal',
-      description: 'Are you sure you want to delete this journal?',
-      cancelText: 'Cancel',
-      confirmText: 'Delete',
-      onCancel: () => Navigator.pop(context, false),
-      onConfirm: () => Navigator.pop(context, true),
-    ),
+    builder:
+        (context) => ConfirmationDialog(
+          title: 'Delete Journal',
+          description: 'Are you sure you want to delete this journal?',
+          cancelText: 'Cancel',
+          confirmText: 'Delete',
+          onCancel: () => Navigator.pop(context, false),
+          onConfirm: () => Navigator.pop(context, true),
+        ),
   );
   return shouldDelete == true;
 }
@@ -63,14 +66,14 @@ Future<void> deleteJournal(
   String journalId,
 ) async {
   try {
-    CustomToast.init(context);
-    await ref.read(journalsControllerProvider.notifier).removeJournal(journalId);
+    await ref
+        .read(journalsControllerProvider.notifier)
+        .removeJournal(journalId);
 
     if (!context.mounted) return;
-    CustomToast.showSuccess('Journal deleted successfully');
+    CustomToast.showSuccess(context, 'Journal deleted successfully');
   } catch (e) {
     if (!context.mounted) return;
-    CustomToast.init(context);
-    CustomToast.showError('Failed to delete journal');
+    CustomToast.showError(context, 'Failed to delete journal');
   }
 }

--- a/lib/features/journal/widgets/reviews_bottom_sheet.dart
+++ b/lib/features/journal/widgets/reviews_bottom_sheet.dart
@@ -7,6 +7,18 @@ import 'package:movie_journal/features/quesgen/provider.dart';
 class ReviewsBottomSheet extends ConsumerWidget {
   const ReviewsBottomSheet({super.key});
 
+  /// The one way to open this sheet — ThoughtsScreen and ReviewsFloatingButton
+  /// used to carry byte-identical copies of this call.
+  static void show(BuildContext context) {
+    showModalBottomSheet(
+      useSafeArea: true,
+      isScrollControlled: true,
+      context: context,
+      backgroundColor: const Color(0xFF171717),
+      builder: (context) => const Wrap(children: [ReviewsBottomSheet()]),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final quesgenState = ref.watch(quesgenControllerProvider);

--- a/lib/features/journal/widgets/reviews_floating_button.dart
+++ b/lib/features/journal/widgets/reviews_floating_button.dart
@@ -24,13 +24,7 @@ class _ReviewsFloatingButtonState extends ConsumerState<ReviewsFloatingButton> {
 
   void _openBottomSheet() {
     if (!mounted) return;
-    showModalBottomSheet(
-      useSafeArea: true,
-      isScrollControlled: true,
-      context: context,
-      backgroundColor: const Color(0xFF171717),
-      builder: (context) => const Wrap(children: [ReviewsBottomSheet()]),
-    );
+    ReviewsBottomSheet.show(context);
   }
 
   void _onPressed() {

--- a/lib/features/journal/widgets/scene_card.dart
+++ b/lib/features/journal/widgets/scene_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 
 class SceneCard extends StatefulWidget {
   final String imagePath;
@@ -64,7 +65,7 @@ class _SceneCardState extends State<SceneCard> {
             topRight: Radius.circular(8),
           ),
           child: Image.network(
-            'https://image.tmdb.org/t/p/w500${widget.imagePath}',
+            tmdbImageUrl(widget.imagePath, TmdbImageSize.w500),
             width: double.infinity,
             height: 235,
             fit: BoxFit.cover,
@@ -130,7 +131,7 @@ class _SceneCardState extends State<SceneCard> {
       child: Stack(
         children: [
           Image.network(
-            'https://image.tmdb.org/t/p/w500${widget.imagePath}',
+            tmdbImageUrl(widget.imagePath, TmdbImageSize.w500),
             width: double.infinity,
             height: 235,
             fit: BoxFit.cover,

--- a/lib/features/journal/widgets/scenes_select_sheet.dart
+++ b/lib/features/journal/widgets/scenes_select_sheet.dart
@@ -5,7 +5,8 @@ import 'package:movie_journal/features/journal/controllers/journal.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
 import 'package:movie_journal/features/movie/data/models/movie_image.dart';
 import 'package:movie_journal/features/toast/custom_toast.dart';
-import 'package:movie_journal/shared_widgets/action_text_button.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
+import 'package:movie_journal/shared_widgets/sheet_app_bar.dart';
 
 class SceneGridTile extends StatelessWidget {
   const SceneGridTile({
@@ -137,8 +138,7 @@ class _ScenesSelectSheetState extends ConsumerState<ScenesSelectSheet> {
                 child: GridView.builder(
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
-                  gridDelegate:
-                      const SliverGridDelegateWithFixedCrossAxisCount(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 2,
                     crossAxisSpacing: 8,
                     mainAxisSpacing: 8,
@@ -156,8 +156,10 @@ class _ScenesSelectSheetState extends ConsumerState<ScenesSelectSheet> {
 
                     return SceneGridTile(
                       index: selectedIndex,
-                      imageUrl:
-                          'https://image.tmdb.org/t/p/w500${backdrops[index].filePath}',
+                      imageUrl: tmdbImageUrl(
+                        backdrops[index].filePath,
+                        TmdbImageSize.w500,
+                      ),
                       isSelected: isSelected,
                       onTap: () {
                         if (isSelected) {
@@ -169,8 +171,8 @@ class _ScenesSelectSheetState extends ConsumerState<ScenesSelectSheet> {
                           return;
                         }
                         if (_localSelectedScenes.length >= _maxSceneLimit) {
-                          CustomToast.init(context);
                           CustomToast.showError(
+                            context,
                             'You can select up to $_maxSceneLimit scenes',
                           );
                           return;
@@ -189,40 +191,16 @@ class _ScenesSelectSheetState extends ConsumerState<ScenesSelectSheet> {
           ],
         ),
       ),
-      appBar: AppBar(
+      appBar: SheetAppBar(
+        title: 'Scenes',
         backgroundColor: Theme.of(context).colorScheme.surface,
-        automaticallyImplyLeading: false,
-        titleSpacing: 0,
-        title: Row(
-          children: [
-            ActionTextButton(
-              text: 'Cancel',
-              color: Colors.white,
-              onPressed: () {
-                Navigator.pop(context);
-              },
-            ),
-            const Expanded(
-              child: Center(
-                child: Text(
-                  'Scenes',
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
-                ),
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          ActionTextButton(
-            text: 'Done',
-            onPressed: () {
-              ref
-                  .read(journalControllerProvider.notifier)
-                  .setSelectedScenes(_localSelectedScenes);
-              Navigator.pop(context);
-            },
-          ),
-        ],
+        onCancel: () => Navigator.pop(context),
+        onDone: () {
+          ref
+              .read(journalControllerProvider.notifier)
+              .setSelectedScenes(_localSelectedScenes);
+          Navigator.pop(context);
+        },
       ),
     );
   }

--- a/lib/features/journal/widgets/scenes_select_sheet.dart
+++ b/lib/features/journal/widgets/scenes_select_sheet.dart
@@ -7,8 +7,8 @@ import 'package:movie_journal/features/movie/data/models/movie_image.dart';
 import 'package:movie_journal/features/toast/custom_toast.dart';
 import 'package:movie_journal/shared_widgets/action_text_button.dart';
 
-class SceneButton extends StatelessWidget {
-  const SceneButton({
+class SceneGridTile extends StatelessWidget {
+  const SceneGridTile({
     super.key,
     required this.index,
     required this.imageUrl,
@@ -154,7 +154,7 @@ class _ScenesSelectSheetState extends ConsumerState<ScenesSelectSheet> {
                       (scene) => scene.path == backdrop.filePath,
                     );
 
-                    return SceneButton(
+                    return SceneGridTile(
                       index: selectedIndex,
                       imageUrl:
                           'https://image.tmdb.org/t/p/w500${backdrops[index].filePath}',

--- a/lib/features/journal/widgets/scenes_selector.dart
+++ b/lib/features/journal/widgets/scenes_selector.dart
@@ -6,8 +6,8 @@ import 'package:movie_journal/features/journal/widgets/scenes_select_sheet.dart'
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
 
-class SceneButton extends StatelessWidget {
-  const SceneButton({
+class SelectedSceneCard extends StatelessWidget {
+  const SelectedSceneCard({
     super.key,
     required this.imageUrl,
     required this.onRemove,
@@ -206,7 +206,7 @@ class _ScenesSelectorState extends ConsumerState<ScenesSelector> {
             separatorBuilder: (context, index) => const SizedBox(width: 8),
             itemBuilder: (context, index) {
               final scene = selectedScenes[index];
-              return SceneButton(
+              return SelectedSceneCard(
                 imageUrl: 'https://image.tmdb.org/t/p/w500${scene.path}',
                 sceneIndex: index,
                 caption: scene.caption,

--- a/lib/features/journal/widgets/scenes_selector.dart
+++ b/lib/features/journal/widgets/scenes_selector.dart
@@ -5,6 +5,7 @@ import 'package:movie_journal/features/journal/screens/caption_editor.dart';
 import 'package:movie_journal/features/journal/widgets/scenes_select_sheet.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 
 class SelectedSceneCard extends StatelessWidget {
   const SelectedSceneCard({
@@ -150,7 +151,7 @@ class _ScenesSelectorState extends ConsumerState<ScenesSelector> {
           ClipRRect(
             borderRadius: BorderRadius.circular(_borderRadius),
             child: Image.network(
-              'https://image.tmdb.org/t/p/w342$firstBackdropPath',
+              tmdbImageUrl(firstBackdropPath, TmdbImageSize.w342),
               fit: BoxFit.cover,
               width: double.infinity,
               height: double.infinity,
@@ -207,7 +208,7 @@ class _ScenesSelectorState extends ConsumerState<ScenesSelector> {
             itemBuilder: (context, index) {
               final scene = selectedScenes[index];
               return SelectedSceneCard(
-                imageUrl: 'https://image.tmdb.org/t/p/w500${scene.path}',
+                imageUrl: tmdbImageUrl(scene.path, TmdbImageSize.w500),
                 sceneIndex: index,
                 caption: scene.caption,
                 onRemove: () {

--- a/lib/features/login/screens/create_user.dart
+++ b/lib/features/login/screens/create_user.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:movie_journal/analytics_manager.dart';
+import 'package:movie_journal/features/toast/custom_toast.dart';
 import 'package:movie_journal/features/auth/auth_providers.dart';
 import 'package:movie_journal/features/home/screens/home.dart';
 import 'package:movie_journal/supabase_auth_manager.dart';
@@ -66,12 +66,6 @@ class _CreateUserScreenState extends ConsumerState<CreateUserScreen> {
   bool _isLoading = false;
 
   @override
-  void initState() {
-    super.initState();
-    AnalyticsManager.logScreenView('CreateUser');
-  }
-
-  @override
   void dispose() {
     _usernameController.dispose();
     super.dispose();
@@ -99,13 +93,11 @@ class _CreateUserScreenState extends ConsumerState<CreateUserScreen> {
     // Validate username format
     final validationError = validateUsername(username);
     if (validationError != null) {
-      unawaited(
-        Fluttertoast.showToast(
-          msg: validationError,
-          backgroundColor: Colors.red,
-          toastLength: Toast.LENGTH_LONG,
-          gravity: ToastGravity.TOP,
-        ),
+      // TOP so the toast stays visible above the keyboard.
+      CustomToast.showError(
+        context,
+        validationError,
+        gravity: ToastGravity.TOP,
       );
       return;
     }
@@ -117,13 +109,10 @@ class _CreateUserScreenState extends ConsumerState<CreateUserScreen> {
       final available = await _checkUsernameAvailable(username);
       if (!available) {
         if (mounted) {
-          unawaited(
-            Fluttertoast.showToast(
-              msg: 'Username already taken. Please choose another one.',
-              backgroundColor: Colors.red,
-              toastLength: Toast.LENGTH_LONG,
-              gravity: ToastGravity.TOP,
-            ),
+          CustomToast.showError(
+            context,
+            'Username already taken. Please choose another one.',
+            gravity: ToastGravity.TOP,
           );
         }
         return;
@@ -153,14 +142,7 @@ class _CreateUserScreenState extends ConsumerState<CreateUserScreen> {
       }
     } catch (e) {
       if (mounted) {
-        unawaited(
-          Fluttertoast.showToast(
-            msg: 'Error: $e',
-            backgroundColor: Colors.red,
-            toastLength: Toast.LENGTH_LONG,
-            gravity: ToastGravity.TOP,
-          ),
-        );
+        CustomToast.showError(context, 'Error: $e', gravity: ToastGravity.TOP);
       }
     } finally {
       if (mounted) {
@@ -185,123 +167,132 @@ class _CreateUserScreenState extends ConsumerState<CreateUserScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.only(left: 32.0, right: 32.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              // Title
-              const Text(
-                'Pick a name.',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 20,
-                  height: 1.5,
-                  fontWeight: FontWeight.bold,
-                  fontFamily: 'AvenirNext',
+    return ScreenViewTracker(
+      screenName: 'CreateUser',
+      child: Scaffold(
+        backgroundColor: Colors.black,
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.only(left: 32.0, right: 32.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                // Title
+                const Text(
+                  'Pick a name.',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    height: 1.5,
+                    fontWeight: FontWeight.bold,
+                    fontFamily: 'AvenirNext',
+                  ),
+                  textAlign: TextAlign.center,
                 ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 4),
-              // Subtitle
-              const Text(
-                'Tell me more about you.',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 16,
-                  fontFamily: 'AvenirNext',
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 24),
-              // Username label
-              const Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  'Username',
-                  style: TextStyle(color: Colors.white70, fontSize: 14),
-                ),
-              ),
-              const SizedBox(height: 8),
-              // Username input field
-              TextField(
-                controller: _usernameController,
-                enabled: !_isLoading,
-                autocorrect: false,
-                style: const TextStyle(color: Colors.white, fontSize: 16),
-                decoration: InputDecoration(
-                  hintText: 'name or nickname',
-                  hintStyle: TextStyle(
-                    color: Colors.white.withAlpha(76),
+                const SizedBox(height: 4),
+                // Subtitle
+                const Text(
+                  'Tell me more about you.',
+                  style: TextStyle(
+                    color: Colors.white,
                     fontSize: 16,
+                    fontFamily: 'AvenirNext',
                   ),
-                  filled: false,
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: const BorderSide(color: Colors.white, width: 1),
-                  ),
-                  focusedBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: const BorderSide(color: Colors.white, width: 2),
-                  ),
-                  disabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    borderSide: BorderSide(
-                      color: Colors.white.withAlpha(76),
-                      width: 1,
-                    ),
-                  ),
-                  contentPadding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 16,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                // Username label
+                const Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    'Username',
+                    style: TextStyle(color: Colors.white70, fontSize: 14),
                   ),
                 ),
-              ),
-              const SizedBox(height: 76),
-              // Start Journaling button
-              SizedBox(
-                width: double.infinity,
-                height: 56,
-                child: ElevatedButton(
-                  onPressed: _isLoading ? null : _handleStartJournaling,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(
-                      0xFFB4E4E4,
-                    ), // Light blue color
-                    disabledBackgroundColor: const Color(
-                      0xFFB4E4E4,
-                    ).withAlpha(127),
-                    shape: RoundedRectangleBorder(
+                const SizedBox(height: 8),
+                // Username input field
+                TextField(
+                  controller: _usernameController,
+                  enabled: !_isLoading,
+                  autocorrect: false,
+                  style: const TextStyle(color: Colors.white, fontSize: 16),
+                  decoration: InputDecoration(
+                    hintText: 'name or nickname',
+                    hintStyle: TextStyle(
+                      color: Colors.white.withAlpha(76),
+                      fontSize: 16,
+                    ),
+                    filled: false,
+                    enabledBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
+                      borderSide: const BorderSide(
+                        color: Colors.white,
+                        width: 1,
+                      ),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: const BorderSide(
+                        color: Colors.white,
+                        width: 2,
+                      ),
+                    ),
+                    disabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide(
+                        color: Colors.white.withAlpha(76),
+                        width: 1,
+                      ),
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 16,
                     ),
                   ),
-                  child:
-                      _isLoading
-                          ? const SizedBox(
-                            height: 24,
-                            width: 24,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                Colors.black,
+                ),
+                const SizedBox(height: 76),
+                // Start Journaling button
+                SizedBox(
+                  width: double.infinity,
+                  height: 56,
+                  child: ElevatedButton(
+                    onPressed: _isLoading ? null : _handleStartJournaling,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(
+                        0xFFB4E4E4,
+                      ), // Light blue color
+                      disabledBackgroundColor: const Color(
+                        0xFFB4E4E4,
+                      ).withAlpha(127),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                    child:
+                        _isLoading
+                            ? const SizedBox(
+                              height: 24,
+                              width: 24,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                  Colors.black,
+                                ),
+                              ),
+                            )
+                            : const Text(
+                              'Start Journaling',
+                              style: TextStyle(
+                                color: Colors.black,
+                                fontSize: 18,
+                                fontWeight: FontWeight.w600,
                               ),
                             ),
-                          )
-                          : const Text(
-                            'Start Journaling',
-                            style: TextStyle(
-                              color: Colors.black,
-                              fontSize: 18,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
+                  ),
                 ),
-              ),
-              const SizedBox(height: 32),
-            ],
+                const SizedBox(height: 32),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/login/screens/login.dart
+++ b/lib/features/login/screens/login.dart
@@ -35,12 +35,6 @@ class LoginScreen extends StatefulWidget {
 class _LoginScreenState extends State<LoginScreen> {
   bool _isLoading = false;
 
-  @override
-  void initState() {
-    super.initState();
-    AnalyticsManager.logScreenView('Login');
-  }
-
   /// Cancelled prompts stay silent — backing out of the Apple/Google sheet is
   /// an ordinary choice, not a failure. Real faults get an error toast; the
   /// success path needs no navigation because `home.dart` reacts to the auth
@@ -57,8 +51,7 @@ class _LoginScreenState extends State<LoginScreen> {
     } catch (e) {
       debugPrint('Sign-in with $method failed: $e');
       if (mounted) {
-        CustomToast.init(context);
-        CustomToast.showError('Sign-in failed. Please try again.');
+        CustomToast.showError(context, 'Sign-in failed. Please try again.');
       }
     } finally {
       if (mounted) {
@@ -69,57 +62,60 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 32.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Spacer(),
-              // Title
-              const Text(
-                'Start your movie journals.',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 20,
-                  fontWeight: FontWeight.w600,
-                  height: 1.5,
-                  fontFamily: 'AvenirNext',
+    return ScreenViewTracker(
+      screenName: 'Login',
+      child: Scaffold(
+        backgroundColor: Colors.black,
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Spacer(),
+                // Title
+                const Text(
+                  'Start your movie journals.',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    fontWeight: FontWeight.w600,
+                    height: 1.5,
+                    fontFamily: 'AvenirNext',
+                  ),
+                  textAlign: TextAlign.center,
                 ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 16),
-              // Subtitle
-              const Text(
-                'Get started by signing in with your\nGoogle or Apple accounts.',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 16,
-                  height: 1.5,
-                  fontFamily: 'AvenirNext',
+                const SizedBox(height: 16),
+                // Subtitle
+                const Text(
+                  'Get started by signing in with your\nGoogle or Apple accounts.',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    height: 1.5,
+                    fontFamily: 'AvenirNext',
+                  ),
+                  textAlign: TextAlign.center,
                 ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 48),
-              // Sign in with Google button
-              ProviderSignInButton(
-                disabled: _isLoading,
-                onPressed: () => _signIn(widget.googleSignIn, method: 'google'),
-                icon: SvgPicture.asset('assets/images/google_icon.svg'),
-                label: 'Sign in with Google',
-              ),
-              const SizedBox(height: 16),
-              // Sign in with Apple button
-              ProviderSignInButton(
-                disabled: _isLoading,
-                onPressed: () => _signIn(widget.appleSignIn, method: 'apple'),
-                icon: const Icon(Icons.apple, color: Colors.white, size: 28),
-                label: 'Sign in with Apple',
-              ),
-              const Spacer(),
-            ],
+                const SizedBox(height: 48),
+                // Sign in with Google button
+                ProviderSignInButton(
+                  disabled: _isLoading,
+                  onPressed: () => _signIn(widget.googleSignIn, method: 'google'),
+                  icon: SvgPicture.asset('assets/images/google_icon.svg'),
+                  label: 'Sign in with Google',
+                ),
+                const SizedBox(height: 16),
+                // Sign in with Apple button
+                ProviderSignInButton(
+                  disabled: _isLoading,
+                  onPressed: () => _signIn(widget.appleSignIn, method: 'apple'),
+                  icon: const Icon(Icons.apple, color: Colors.white, size: 28),
+                  label: 'Sign in with Apple',
+                ),
+                const Spacer(),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/onboarding/controllers/splash_posters.dart
+++ b/lib/features/onboarding/controllers/splash_posters.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:movie_journal/features/movie/data/data_sources/movie_api.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 
+// Fallback URLs are const, so they can't go through tmdbImageUrl().
 const _imageBaseUrl = 'https://image.tmdb.org/t/p/w342';
 
 const _fallbackPosters = <String>[
@@ -17,11 +19,12 @@ const _fallbackPosters = <String>[
 final splashPostersProvider = FutureProvider<List<String>>((ref) async {
   try {
     final response = await MovieAPI().popularMovies(page: 1);
-    final urls = response.results
-        .where((m) => m.posterPath != null && m.posterPath!.isNotEmpty)
-        .map((m) => '$_imageBaseUrl${m.posterPath}')
-        .take(20)
-        .toList();
+    final urls =
+        response.results
+            .where((m) => m.posterPath != null && m.posterPath!.isNotEmpty)
+            .map((m) => tmdbImageUrl(m.posterPath!, TmdbImageSize.w342))
+            .take(20)
+            .toList();
     return urls.isEmpty ? _fallbackPosters : urls;
   } catch (_) {
     return _fallbackPosters;

--- a/lib/features/onboarding/screens/branding_splash.dart
+++ b/lib/features/onboarding/screens/branding_splash.dart
@@ -23,7 +23,6 @@ class _BrandingSplashScreenState extends ConsumerState<BrandingSplashScreen>
   @override
   void initState() {
     super.initState();
-    AnalyticsManager.logScreenView('OnboardingSplash');
 
     // Pre-warm the poster fetch so it likely arrives during fade-in.
     // ignore: unused_result
@@ -35,9 +34,10 @@ class _BrandingSplashScreenState extends ConsumerState<BrandingSplashScreen>
     );
     _fade = TweenSequence<double>([
       TweenSequenceItem(
-        tween: Tween(begin: 0.0, end: 1.0).chain(
-          CurveTween(curve: Curves.easeOut),
-        ),
+        tween: Tween(
+          begin: 0.0,
+          end: 1.0,
+        ).chain(CurveTween(curve: Curves.easeOut)),
         weight: 20, // 0–600ms fade-in
       ),
       TweenSequenceItem(
@@ -45,9 +45,10 @@ class _BrandingSplashScreenState extends ConsumerState<BrandingSplashScreen>
         weight: 60, // 600–2400ms hold
       ),
       TweenSequenceItem(
-        tween: Tween(begin: 1.0, end: 0.0).chain(
-          CurveTween(curve: Curves.easeIn),
-        ),
+        tween: Tween(
+          begin: 1.0,
+          end: 0.0,
+        ).chain(CurveTween(curve: Curves.easeIn)),
         weight: 20, // 2400–3000ms fade-out
       ),
     ]).animate(_fadeController);
@@ -75,50 +76,53 @@ class _BrandingSplashScreenState extends ConsumerState<BrandingSplashScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: Stack(
-        fit: StackFit.expand,
-        children: [
-          // Bottom marquee strip — clipped to the bottom 380px so the rotated,
-          // overflowing column can never escape this region.
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            height: 380,
-            child: PosterMarquee(progress: _marqueeController),
-          ),
-          // Center brand mark (logo + wordmark are baked into the SVG) and
-          // tagline. The SVG already contains the "i + ticket" mark *and* the
-          // handwritten "Fink" word, so we don't render an extra wordmark here.
-          Center(
-            child: FadeTransition(
-              opacity: _fade,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  SvgPicture.asset(
-                    'assets/images/fink_logo.svg',
-                    height: 160,
-                  ),
-                  const SizedBox(height: 24),
-                  const Text(
-                    'From film to ink,\nBuild your movie journey.',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 16,
-                      height: 1.35,
-                      fontFamily: 'AvenirNext',
-                      fontWeight: FontWeight.w400,
+    return ScreenViewTracker(
+      screenName: 'OnboardingSplash',
+      child: Scaffold(
+        backgroundColor: Colors.black,
+        body: Stack(
+          fit: StackFit.expand,
+          children: [
+            // Bottom marquee strip — clipped to the bottom 380px so the rotated,
+            // overflowing column can never escape this region.
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: 380,
+              child: PosterMarquee(progress: _marqueeController),
+            ),
+            // Center brand mark (logo + wordmark are baked into the SVG) and
+            // tagline. The SVG already contains the "i + ticket" mark *and* the
+            // handwritten "Fink" word, so we don't render an extra wordmark here.
+            Center(
+              child: FadeTransition(
+                opacity: _fade,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SvgPicture.asset(
+                      'assets/images/fink_logo.svg',
+                      height: 160,
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 24),
+                    const Text(
+                      'From film to ink,\nBuild your movie journey.',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 16,
+                        height: 1.35,
+                        fontFamily: 'AvenirNext',
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/search_movie/screens/search_movie.dart
+++ b/lib/features/search_movie/screens/search_movie.dart
@@ -31,7 +31,6 @@ class _SearchMovieScreenState extends ConsumerState<SearchMovieScreen> {
   @override
   void initState() {
     super.initState();
-    AnalyticsManager.logScreenView('SearchMovie');
     scrollController.addListener(_onScroll);
   }
 
@@ -43,65 +42,68 @@ class _SearchMovieScreenState extends ConsumerState<SearchMovieScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      onPopInvokedWithResult: (didPop, result) {
-        if (didPop) {
-          ref.read(searchMovieControllerProvider.notifier).reset();
-        }
-      },
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Add Journal'),
-          centerTitle: false,
-          leadingWidth: 40 + 16,
-          leading: CircledIconButton(
-            onPressed: () {
-              Navigator.pop(context);
-            },
-            icon: Icons.arrow_back_ios_new,
-            outerPadding: const EdgeInsets.only(left: 16),
+    return ScreenViewTracker(
+      screenName: 'SearchMovie',
+      child: PopScope(
+        onPopInvokedWithResult: (didPop, result) {
+          if (didPop) {
+            ref.read(searchMovieControllerProvider.notifier).reset();
+          }
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            title: const Text('Add Journal'),
+            centerTitle: false,
+            leadingWidth: 40 + 16,
+            leading: CircledIconButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              icon: Icons.arrow_back_ios_new,
+              outerPadding: const EdgeInsets.only(left: 16),
+            ),
           ),
-        ),
-        body: Stack(
-          children: [
-            Positioned.fill(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  spacing: 16,
-                  children: [
-                    const MovieSearchBar(),
-                    Expanded(
-                      child: MovieResultList(
-                        scrollController: scrollController,
+          body: Stack(
+            children: [
+              Positioned.fill(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    spacing: 16,
+                    children: [
+                      const MovieSearchBar(),
+                      Expanded(
+                        child: MovieResultList(
+                          scrollController: scrollController,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
-            ),
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: 100,
-              child: IgnorePointer(
-                child: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.bottomCenter,
-                      end: Alignment.topCenter,
-                      colors: [
-                        Theme.of(context).colorScheme.surface,
-                        Colors.transparent,
-                      ],
+              Positioned(
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: 100,
+                child: IgnorePointer(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [
+                          Theme.of(context).colorScheme.surface,
+                          Colors.transparent,
+                        ],
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/search_movie/widgets/movie_result_list.dart
+++ b/lib/features/search_movie/widgets/movie_result_list.dart
@@ -6,6 +6,7 @@ import 'package:movie_journal/features/journal/screens/movie_preview.dart';
 import 'package:movie_journal/features/movie/controllers/search_movie_controller.dart';
 import 'package:movie_journal/features/movie/data/models/brief_movie.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 
 class MovieResultList extends ConsumerWidget {
   final ScrollController scrollController;
@@ -151,7 +152,7 @@ class MovieResultItem extends ConsumerWidget {
               child:
                   movie.posterPath != null
                       ? Image.network(
-                        'https://image.tmdb.org/t/p/w154/${movie.posterPath}',
+                        tmdbImageUrl(movie.posterPath!, TmdbImageSize.w154),
                         width: 96,
                         height: 128,
                         fit: BoxFit.cover,

--- a/lib/features/settings/screens/settings.dart
+++ b/lib/features/settings/screens/settings.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:movie_journal/analytics_manager.dart';
+import 'package:movie_journal/features/toast/custom_toast.dart';
 import 'package:movie_journal/features/account_link/controllers/account_link.dart';
 import 'package:movie_journal/features/account_link/widgets/secure_account_sheet.dart';
 import 'package:movie_journal/features/auth/auth_providers.dart';
@@ -232,12 +233,7 @@ class _AccountSection extends ConsumerWidget {
       if (!confirmed) return; // user backed out of the prompt
     } catch (e) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Re-authentication required: $e'),
-            backgroundColor: Colors.red,
-          ),
-        );
+        CustomToast.showError(context, 'Re-authentication required: $e');
       }
       return;
     }
@@ -266,12 +262,7 @@ class _AccountSection extends ConsumerWidget {
       }
     } catch (e) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Failed to delete account: $e'),
-            backgroundColor: Colors.red,
-          ),
-        );
+        CustomToast.showError(context, 'Failed to delete account: $e');
       }
     }
   }

--- a/lib/features/share/screens/share_ticket_screen.dart
+++ b/lib/features/share/screens/share_ticket_screen.dart
@@ -67,7 +67,6 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
   @override
   void initState() {
     super.initState();
-    AnalyticsManager.logScreenView('ShareTicket');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref
           .read(movieDetailControllerProvider.notifier)
@@ -80,7 +79,6 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
 
   void _showShareBottomSheet() {
     final thoughts = widget.journal.thoughts;
-    CustomToast.init(context);
 
     showModalBottomSheet(
       context: context,
@@ -162,7 +160,7 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
                             behavior: HitTestBehavior.opaque,
                             onTap: () {
                               Clipboard.setData(ClipboardData(text: thoughts));
-                              CustomToast.showSuccess('Copied to clipboard');
+                              CustomToast.showSuccess(context, 'Copied to clipboard');
                             },
                             child: Padding(
                               // Vertical padding enlarges the touch target so it
@@ -182,7 +180,9 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
                                     style: TextStyle(
                                       fontSize: 14,
                                       fontWeight: FontWeight.w500,
-                                      color: Colors.white.withValues(alpha: 0.7),
+                                      color: Colors.white.withValues(
+                                        alpha: 0.7,
+                                      ),
                                       fontFamily: 'AvenirNext',
                                     ),
                                   ),
@@ -355,8 +355,6 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
   }
 
   Future<void> _shareToInstagramStory() async {
-    CustomToast.init(context);
-
     try {
       final file = await _captureTicketToFile('movie_ticket_story.png');
       if (file == null) return;
@@ -382,14 +380,15 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
     } catch (e) {
       debugPrint('Instagram Story share error: $e');
       if (mounted) {
-        CustomToast.showError('Could not open Instagram. Is it installed?');
+        CustomToast.showError(
+          context,
+          'Could not open Instagram. Is it installed?',
+        );
       }
     }
   }
 
   Future<void> _shareToThreads() async {
-    CustomToast.init(context);
-
     try {
       final text = _composeThreadsText();
       final uri = Uri.parse(
@@ -406,13 +405,16 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
         );
       } else {
         if (mounted) {
-          CustomToast.showError('Could not open Threads. Is it installed?');
+          CustomToast.showError(
+            context,
+            'Could not open Threads. Is it installed?',
+          );
         }
       }
     } catch (e) {
       debugPrint('Threads share error: $e');
       if (mounted) {
-        CustomToast.showError('Could not open Threads');
+        CustomToast.showError(context, 'Could not open Threads');
       }
     }
   }
@@ -449,7 +451,6 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
   Future<void> _saveImage() async {
     if (_saving) return;
     setState(() => _saving = true);
-    CustomToast.init(context);
 
     try {
       // Request gallery permission
@@ -458,7 +459,7 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
         final granted = await Gal.requestAccess();
         if (!granted) {
           if (mounted) {
-            CustomToast.showError('Photo library access denied');
+            CustomToast.showError(context, 'Photo library access denied');
           }
           return;
         }
@@ -473,12 +474,12 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
       );
 
       if (mounted) {
-        CustomToast.showSuccess('Image saved to camera roll');
+        CustomToast.showSuccess(context, 'Image saved to camera roll');
       }
     } catch (e) {
       debugPrint('Save image error: $e');
       if (mounted) {
-        CustomToast.showError('Failed to save image');
+        CustomToast.showError(context, 'Failed to save image');
       }
     } finally {
       if (mounted) {
@@ -498,9 +499,8 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
     if (!asyncJournals.hasValue) return 0;
     final journals = asyncJournals.value?.journals;
     if (journals == null || journals.isEmpty) return 0;
-    final sorted = [...journals]..sort(
-      (a, b) => a.createdAt.dateTime.compareTo(b.createdAt.dateTime),
-    );
+    final sorted = [...journals]
+      ..sort((a, b) => a.createdAt.dateTime.compareTo(b.createdAt.dateTime));
     final index = sorted.indexWhere((j) => j.id == journalId);
     return index == -1 ? 0 : index + 1;
   }
@@ -513,7 +513,9 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
 
     final journal = widget.journal;
     final isLoading =
-        asyncMovie.isLoading || asyncImages.isLoading || asyncJournals.isLoading;
+        asyncMovie.isLoading ||
+        asyncImages.isLoading ||
+        asyncJournals.isLoading;
 
     // Extract movie details
     final movie = asyncMovie.hasValue ? asyncMovie.value : null;
@@ -538,102 +540,107 @@ class _ShareTicketScreenState extends ConsumerState<ShareTicketScreen> {
 
     final ticketNumber = _computeTicketNumber(asyncJournals, journal.id);
 
-    return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.surface,
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        leadingWidth: 56,
-        leading: Padding(
-          padding: const EdgeInsets.only(left: 16),
-          child: CircledIconButton(
-            icon: Icons.arrow_back_ios_new,
-            onPressed: () => Navigator.of(context).pop(),
-          ),
-        ),
-        centerTitle: true,
-        actions: [
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: IconButton(
-              onPressed: _onClose,
-              icon: const Icon(Icons.close, color: Colors.white, size: 24),
+    return ScreenViewTracker(
+      screenName: 'ShareTicket',
+      child: Scaffold(
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          leadingWidth: 56,
+          leading: Padding(
+            padding: const EdgeInsets.only(left: 16),
+            child: CircledIconButton(
+              icon: Icons.arrow_back_ios_new,
+              onPressed: () => Navigator.of(context).pop(),
             ),
           ),
-        ],
-      ),
-      body:
-          isLoading
-              ? const Center(child: CircularProgressIndicator())
-              : Column(
-                children: [
-                  Expanded(
-                    child: Center(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 32),
-                        child: AspectRatio(
-                          aspectRatio: 2 / 3,
-                          child: RepaintBoundary(
-                            key: _repaintKey,
-                            child: FlippableTicket(
-                              hintOnMount: true,
-                              front: TicketFront(
-                                posterPath:
-                                    widget.posterPath ?? journal.moviePoster,
-                              ),
-                              back: TicketBack(
-                                movieTitle: journal.movieTitle,
-                                year: year,
-                                releaseDate: releaseDate,
-                                director: director,
-                                cast: cast,
-                                emotions: journal.emotions,
-                                scenePath: scenePath,
-                                createdAt: journal.createdAt,
-                                ticketNumber: ticketNumber,
+          centerTitle: true,
+          actions: [
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: IconButton(
+                onPressed: _onClose,
+                icon: const Icon(Icons.close, color: Colors.white, size: 24),
+              ),
+            ),
+          ],
+        ),
+        body:
+            isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : Column(
+                  children: [
+                    Expanded(
+                      child: Center(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 32),
+                          child: AspectRatio(
+                            aspectRatio: 2 / 3,
+                            child: RepaintBoundary(
+                              key: _repaintKey,
+                              child: FlippableTicket(
+                                hintOnMount: true,
+                                front: TicketFront(
+                                  posterPath:
+                                      widget.posterPath ?? journal.moviePoster,
+                                ),
+                                back: TicketBack(
+                                  movieTitle: journal.movieTitle,
+                                  year: year,
+                                  releaseDate: releaseDate,
+                                  director: director,
+                                  cast: cast,
+                                  emotions: journal.emotions,
+                                  scenePath: scenePath,
+                                  createdAt: journal.createdAt,
+                                  ticketNumber: ticketNumber,
+                                ),
                               ),
                             ),
                           ),
                         ),
                       ),
                     ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(24, 16, 24, 40),
-                    child: Row(
-                      children: [
-                        CircledIconButton(
-                          icon: Icons.download,
-                          onPressed: _saving ? null : _saveImage,
-                          iconSize: 20,
-                          size: 48,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: _showShareBottomSheet,
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor:
-                                  Theme.of(context).colorScheme.primary,
-                              foregroundColor: Colors.black,
-                              padding: const EdgeInsets.symmetric(vertical: 16),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16),
-                              ),
-                              textStyle: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w600,
-                                fontFamily: 'AvenirNext',
-                              ),
-                            ),
-                            child: const Text('Share'),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(24, 16, 24, 40),
+                      child: Row(
+                        children: [
+                          CircledIconButton(
+                            icon: Icons.download,
+                            onPressed: _saving ? null : _saveImage,
+                            iconSize: 20,
+                            size: 48,
                           ),
-                        ),
-                      ],
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: ElevatedButton(
+                              onPressed: _showShareBottomSheet,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor:
+                                    Theme.of(context).colorScheme.primary,
+                                foregroundColor: Colors.black,
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 16,
+                                ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                                textStyle: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                  fontFamily: 'AvenirNext',
+                                ),
+                              ),
+                              child: const Text('Share'),
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
-                  ),
-                ],
-              ),
+                  ],
+                ),
+      ),
     );
   }
 }

--- a/lib/features/share/screens/ticket_poster_picker_screen.dart
+++ b/lib/features/share/screens/ticket_poster_picker_screen.dart
@@ -5,6 +5,7 @@ import 'package:movie_journal/features/movie/data/models/movie_image.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
 import 'package:movie_journal/features/share/screens/share_ticket_screen.dart';
 import 'package:movie_journal/analytics_manager.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 
 class TicketPosterPickerScreen extends ConsumerStatefulWidget {
   final JournalState journal;
@@ -50,7 +51,6 @@ class _TicketPosterPickerScreenState
   @override
   void initState() {
     super.initState();
-    AnalyticsManager.logScreenView('TicketPosterPicker');
     _pageController = PageController();
     _pageController.addListener(_onPageScroll);
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -93,11 +93,12 @@ class _TicketPosterPickerScreenState
     final original = _resolvedOriginalLanguage;
     if (original == null) return;
     final originalBase = original.split('-').first.toLowerCase();
-    final filtered = _allLanguageTabs.where((tab) {
-      final code = tab.$2;
-      if (code == null) return true;
-      return code.split('-').first.toLowerCase() != originalBase;
-    }).toList();
+    final filtered =
+        _allLanguageTabs.where((tab) {
+          final code = tab.$2;
+          if (code == null) return true;
+          return code.split('-').first.toLowerCase() != originalBase;
+        }).toList();
     if (filtered.length == _languageTabs.length) return;
     if (!mounted) return;
     setState(() {
@@ -172,159 +173,165 @@ class _TicketPosterPickerScreenState
       context,
       MaterialPageRoute(
         settings: const RouteSettings(name: kShareFlowRouteName),
-        builder: (context) => ShareTicketScreen(
-          journal: widget.journal,
-          posterPath: path,
-          entry: widget.entry,
-        ),
+        builder:
+            (context) => ShareTicketScreen(
+              journal: widget.journal,
+              posterPath: path,
+              entry: widget.entry,
+            ),
       ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.surface,
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        automaticallyImplyLeading: false,
-        centerTitle: true,
-        title: const Text(
-          'Choose a Ticket Poster',
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-            color: Colors.white,
-            fontFamily: 'AvenirNext',
+    return ScreenViewTracker(
+      screenName: 'TicketPosterPicker',
+      child: Scaffold(
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          automaticallyImplyLeading: false,
+          centerTitle: true,
+          title: const Text(
+            'Choose a Ticket Poster',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+              fontFamily: 'AvenirNext',
+            ),
           ),
+          actions: [
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: IconButton(
+                onPressed: () => closeShareFlow(context, widget.entry),
+                icon: const Icon(Icons.close, color: Colors.white, size: 24),
+              ),
+            ),
+          ],
         ),
-        actions: [
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: IconButton(
-              onPressed: () => closeShareFlow(context, widget.entry),
-              icon: const Icon(Icons.close, color: Colors.white, size: 24),
-            ),
-          ),
-        ],
-      ),
-      body: Column(
-        children: [
-          // Language tabs
-          SizedBox(
-            height: 48,
-            child: ListView.separated(
-              scrollDirection: Axis.horizontal,
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              itemCount: _languageTabs.length,
-              separatorBuilder: (_, _) => const SizedBox(width: 8),
-              itemBuilder: (context, index) {
-                final isSelected = index == _selectedTabIndex;
-                return GestureDetector(
-                  key: _tabKeys[index],
-                  onTap: () => _onTabSelected(index),
-                  child: Center(
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 8,
-                      ),
-                      decoration: BoxDecoration(
-                        color: isSelected
-                            ? Colors.white.withAlpha(179) // 70%
-                            : Colors.white.withAlpha(38), // 15%
-                        borderRadius: BorderRadius.circular(20),
-                        border: Border.all(
-                          color: isSelected
-                              ? Colors.white.withAlpha(230) // 90%
-                              : Colors.transparent,
+        body: Column(
+          children: [
+            // Language tabs
+            SizedBox(
+              height: 48,
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: _languageTabs.length,
+                separatorBuilder: (_, _) => const SizedBox(width: 8),
+                itemBuilder: (context, index) {
+                  final isSelected = index == _selectedTabIndex;
+                  return GestureDetector(
+                    key: _tabKeys[index],
+                    onTap: () => _onTabSelected(index),
+                    child: Center(
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
                         ),
-                      ),
-                      child: Text(
-                        _languageTabs[index].$1,
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w600,
-                          fontFamily: 'AvenirNext',
-                          color: isSelected ? Colors.black : Colors.white,
+                        decoration: BoxDecoration(
+                          color:
+                              isSelected
+                                  ? Colors.white.withAlpha(179) // 70%
+                                  : Colors.white.withAlpha(38), // 15%
+                          borderRadius: BorderRadius.circular(20),
+                          border: Border.all(
+                            color:
+                                isSelected
+                                    ? Colors.white.withAlpha(230) // 90%
+                                    : Colors.transparent,
+                          ),
                         ),
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ),
-          const SizedBox(height: 16),
-
-          // Poster grid pages
-          Expanded(
-            child: PageView.builder(
-              controller: _pageController,
-              itemCount: _languageTabs.length,
-              itemBuilder: (context, pageIndex) {
-                final langCode = _languageCodeForTab(pageIndex);
-                final pagePosters = _posterCache[langCode] ?? [];
-                final isCurrentPage = pageIndex == _selectedTabIndex;
-                final isPageLoading = isCurrentPage && _loading;
-
-                if (isPageLoading) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-
-                if (pagePosters.isEmpty) {
-                  return Center(
-                    child: Text(
-                      'No posters available',
-                      style: TextStyle(
-                        color: Colors.white.withAlpha(128),
-                        fontSize: 14,
-                        fontFamily: 'AvenirNext',
-                      ),
-                    ),
-                  );
-                }
-
-                return GridView.builder(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  gridDelegate:
-                      const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    childAspectRatio: 2 / 3,
-                    crossAxisSpacing: 12,
-                    mainAxisSpacing: 12,
-                  ),
-                  itemCount: pagePosters.length,
-                  itemBuilder: (context, index) {
-                    final poster = pagePosters[index];
-                    return GestureDetector(
-                      onTap: () => _onPosterSelected(poster.filePath),
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(12),
-                        child: Image.network(
-                          'https://image.tmdb.org/t/p/w500${poster.filePath}',
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) =>
-                              Container(
-                            color: const Color(0xFF2C2C2E),
-                            child: const Center(
-                              child: Icon(
-                                Icons.movie,
-                                color: Colors.white54,
-                                size: 48,
-                              ),
-                            ),
+                        child: Text(
+                          _languageTabs[index].$1,
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            fontFamily: 'AvenirNext',
+                            color: isSelected ? Colors.black : Colors.white,
                           ),
                         ),
                       ),
-                    );
-                  },
-                );
-              },
+                    ),
+                  );
+                },
+              ),
             ),
-          ),
-        ],
+            const SizedBox(height: 16),
+
+            // Poster grid pages
+            Expanded(
+              child: PageView.builder(
+                controller: _pageController,
+                itemCount: _languageTabs.length,
+                itemBuilder: (context, pageIndex) {
+                  final langCode = _languageCodeForTab(pageIndex);
+                  final pagePosters = _posterCache[langCode] ?? [];
+                  final isCurrentPage = pageIndex == _selectedTabIndex;
+                  final isPageLoading = isCurrentPage && _loading;
+
+                  if (isPageLoading) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (pagePosters.isEmpty) {
+                    return Center(
+                      child: Text(
+                        'No posters available',
+                        style: TextStyle(
+                          color: Colors.white.withAlpha(128),
+                          fontSize: 14,
+                          fontFamily: 'AvenirNext',
+                        ),
+                      ),
+                    );
+                  }
+
+                  return GridView.builder(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    gridDelegate:
+                        const SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: 2,
+                          childAspectRatio: 2 / 3,
+                          crossAxisSpacing: 12,
+                          mainAxisSpacing: 12,
+                        ),
+                    itemCount: pagePosters.length,
+                    itemBuilder: (context, index) {
+                      final poster = pagePosters[index];
+                      return GestureDetector(
+                        onTap: () => _onPosterSelected(poster.filePath),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(12),
+                          child: Image.network(
+                            tmdbImageUrl(poster.filePath, TmdbImageSize.w500),
+                            fit: BoxFit.cover,
+                            errorBuilder:
+                                (context, error, stackTrace) => Container(
+                                  color: const Color(0xFF2C2C2E),
+                                  child: const Center(
+                                    child: Icon(
+                                      Icons.movie,
+                                      color: Colors.white54,
+                                      size: 48,
+                                    ),
+                                  ),
+                                ),
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/share/widgets/ticket_back.dart
+++ b/lib/features/share/widgets/ticket_back.dart
@@ -3,6 +3,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:jiffy/jiffy.dart';
 import 'package:movie_journal/features/emotion/emotion.dart';
 import 'package:movie_journal/features/share/widgets/film_strip_clipper.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 
 class TicketBack extends StatelessWidget {
   final String movieTitle;
@@ -254,7 +255,7 @@ class TicketBack extends StatelessWidget {
                               BlendMode.saturation,
                             ),
                             child: Image.network(
-                              'https://image.tmdb.org/t/p/w500$scenePath',
+                              tmdbImageUrl(scenePath!, TmdbImageSize.w500),
                               fit: BoxFit.cover,
                               alignment: Alignment.center,
                               errorBuilder:

--- a/lib/features/share/widgets/ticket_front.dart
+++ b/lib/features/share/widgets/ticket_front.dart
@@ -1,29 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:movie_journal/features/share/widgets/film_strip_clipper.dart';
+import 'package:movie_journal/core/utils/tmdb_image_url.dart';
 
 class TicketFront extends StatelessWidget {
   final String posterPath;
 
-  const TicketFront({
-    super.key,
-    required this.posterPath,
-  });
+  const TicketFront({super.key, required this.posterPath});
 
   @override
   Widget build(BuildContext context) {
     return ClipPath(
       clipper: FilmStripClipper(),
       child: Image.network(
-        'https://image.tmdb.org/t/p/w780$posterPath',
+        tmdbImageUrl(posterPath, TmdbImageSize.w780),
         fit: BoxFit.cover,
         width: double.infinity,
         height: double.infinity,
-        errorBuilder: (context, error, stackTrace) => Container(
-          color: const Color(0xFF2C2C2E),
-          child: const Center(
-            child: Icon(Icons.movie, color: Colors.white54, size: 64),
-          ),
-        ),
+        errorBuilder:
+            (context, error, stackTrace) => Container(
+              color: const Color(0xFF2C2C2E),
+              child: const Center(
+                child: Icon(Icons.movie, color: Colors.white54, size: 64),
+              ),
+            ),
       ),
     );
   }

--- a/lib/features/toast/custom_toast.dart
+++ b/lib/features/toast/custom_toast.dart
@@ -2,23 +2,39 @@ import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:movie_journal/themes.dart';
 
+// Re-exported so call sites that need a non-default gravity (e.g. TOP while
+// the keyboard is up) don't have to import fluttertoast themselves.
+export 'package:fluttertoast/fluttertoast.dart' show ToastGravity;
+
 class CustomToast {
   static final FToast _fToast = FToast();
 
-  static void init(BuildContext context) {
-    _fToast.init(context);
-  }
-
-  static void showSuccess(String message) {
-    _show(icon: Icons.check, statusColor: StatusColors.success, message: message);
-  }
-
-  static void showError(String message) {
-    _show(icon: Icons.close, statusColor: StatusColors.error, message: message);
-  }
-
-  static void showWarning(String message) {
+  static void showSuccess(BuildContext context, String message) {
     _show(
+      context: context,
+      icon: Icons.check,
+      statusColor: StatusColors.success,
+      message: message,
+    );
+  }
+
+  static void showError(
+    BuildContext context,
+    String message, {
+    ToastGravity gravity = ToastGravity.BOTTOM,
+  }) {
+    _show(
+      context: context,
+      icon: Icons.close,
+      statusColor: StatusColors.error,
+      message: message,
+      gravity: gravity,
+    );
+  }
+
+  static void showWarning(BuildContext context, String message) {
+    _show(
+      context: context,
       icon: Icons.priority_high,
       statusColor: StatusColors.warning,
       message: message,
@@ -27,13 +43,19 @@ class CustomToast {
 
   /// Shared toast body: a dark bordered card with a filled status-colored icon
   /// circle (black glyph) and the message. Only the icon + accent color vary.
+  ///
+  /// [context] resolves the overlay at show time (FToast is re-inited on every
+  /// call), so callers no longer pair each show with a `CustomToast.init`.
   static void _show({
+    required BuildContext context,
     required IconData icon,
     required Color statusColor,
     required String message,
+    ToastGravity gravity = ToastGravity.BOTTOM,
   }) {
+    _fToast.init(context);
     _fToast.showToast(
-      gravity: ToastGravity.BOTTOM,
+      gravity: gravity,
       toastDuration: const Duration(seconds: 2),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),

--- a/lib/shared_widgets/sheet_app_bar.dart
+++ b/lib/shared_widgets/sheet_app_bar.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:movie_journal/shared_widgets/action_text_button.dart';
+
+/// The Cancel / centered-title / Done app bar used by the full-screen sheets
+/// (ThoughtsScreen, ScenesSelectSheet, CaptionEditor).
+///
+/// [title] is optional — CaptionEditor shows only the two actions.
+class SheetAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const SheetAppBar({
+    super.key,
+    this.title,
+    required this.onCancel,
+    required this.onDone,
+    this.backgroundColor,
+  });
+
+  final String? title;
+  final VoidCallback onCancel;
+  final VoidCallback onDone;
+  final Color? backgroundColor;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      backgroundColor: backgroundColor,
+      elevation: 0,
+      automaticallyImplyLeading: false,
+      titleSpacing: 0,
+      title: Row(
+        children: [
+          ActionTextButton(
+            text: 'Cancel',
+            color: Colors.white,
+            onPressed: onCancel,
+          ),
+          if (title != null)
+            Expanded(
+              child: Center(
+                child: Text(
+                  title!,
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+      actions: [ActionTextButton(text: 'Done', onPressed: onDone)],
+    );
+  }
+}

--- a/lib/themes.dart
+++ b/lib/themes.dart
@@ -8,9 +8,10 @@ const String _defaultFontFamily = 'Inter';
 
 /// Single source of truth for status accent colors (toast icons, etc.).
 ///
-/// These are context-free constants because some consumers — e.g.
-/// [CustomToast.showError] — run without a [BuildContext]. Used as icon
-/// *background* colors; the inner glyph is always plain black for contrast.
+/// Context-free constants rather than a [ThemeExtension]: they are the same in
+/// every theme, and consumers shouldn't need a [BuildContext] just to pick an
+/// accent. Used as icon *background* colors; the inner glyph is always plain
+/// black for contrast.
 class StatusColors {
   StatusColors._();
 

--- a/test/features/journal/widgets/scenes_select_sheet_test.dart
+++ b/test/features/journal/widgets/scenes_select_sheet_test.dart
@@ -75,7 +75,7 @@ void main() {
       await tester.pumpWidget(buildSubject(container));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(SceneButton).first);
+      await tester.tap(find.byType(SceneGridTile).first);
       await tester.pump();
 
       expect(find.text('Select up to 10 (1/10)'), findsOneWidget);
@@ -97,13 +97,13 @@ void main() {
 
       // Fill the cap.
       for (var i = 0; i < 10; i++) {
-        await tester.tap(find.byType(SceneButton).at(i));
+        await tester.tap(find.byType(SceneGridTile).at(i));
         await tester.pump();
       }
       expect(find.text('Select up to 10 (10/10)'), findsOneWidget);
 
       // Tapping an 11th is blocked: count holds at 10/10 and a toast appears.
-      await tester.tap(find.byType(SceneButton).at(10));
+      await tester.tap(find.byType(SceneGridTile).at(10));
       await tester.pump();
       expect(find.text('Select up to 10 (10/10)'), findsOneWidget);
       expect(find.text('You can select up to 10 scenes'), findsWidgets);

--- a/test/features/toast/custom_toast_test.dart
+++ b/test/features/toast/custom_toast_test.dart
@@ -14,13 +14,11 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: Builder(
-            builder: (context) => ElevatedButton(
-              onPressed: () {
-                CustomToast.init(context);
-                show(context);
-              },
-              child: const Text('go'),
-            ),
+            builder:
+                (context) => ElevatedButton(
+                  onPressed: () => show(context),
+                  child: const Text('go'),
+                ),
           ),
         ),
       ),
@@ -32,7 +30,9 @@ void main() {
   // The icon circle is the nearest Container ancestor of the glyph.
   BoxDecoration circleOf(WidgetTester tester, IconData icon) {
     final container = tester.widget<Container>(
-      find.ancestor(of: find.byIcon(icon), matching: find.byType(Container)).first,
+      find
+          .ancestor(of: find.byIcon(icon), matching: find.byType(Container))
+          .first,
     );
     return container.decoration as BoxDecoration;
   }
@@ -43,9 +43,10 @@ void main() {
   }
 
   group('CustomToast status → color mapping', () {
-    testWidgets('success uses the primary status color with a black check',
-        (tester) async {
-      await showToast(tester, (c) => CustomToast.showSuccess('Saved'));
+    testWidgets('success uses the primary status color with a black check', (
+      tester,
+    ) async {
+      await showToast(tester, (c) => CustomToast.showSuccess(c, 'Saved'));
 
       expect(find.text('Saved'), findsWidgets);
       expect(tester.widget<Icon>(find.byIcon(Icons.check)).color, Colors.black);
@@ -56,9 +57,10 @@ void main() {
       await drainToastTimers(tester);
     });
 
-    testWidgets('error uses the error status color with a black cross',
-        (tester) async {
-      await showToast(tester, (_) => CustomToast.showError('Nope'));
+    testWidgets('error uses the error status color with a black cross', (
+      tester,
+    ) async {
+      await showToast(tester, (c) => CustomToast.showError(c, 'Nope'));
 
       expect(find.text('Nope'), findsWidgets);
       expect(tester.widget<Icon>(find.byIcon(Icons.close)).color, Colors.black);
@@ -67,9 +69,10 @@ void main() {
       await drainToastTimers(tester);
     });
 
-    testWidgets('warning uses the warning status color with a black bang',
-        (tester) async {
-      await showToast(tester, (_) => CustomToast.showWarning('Careful'));
+    testWidgets('warning uses the warning status color with a black bang', (
+      tester,
+    ) async {
+      await showToast(tester, (c) => CustomToast.showWarning(c, 'Careful'));
 
       expect(find.text('Careful'), findsWidgets);
       expect(


### PR DESCRIPTION
## Summary
ISA-11 item 3 (ISA-7 Phase 4). Stacked on #26 (which is stacked on #25) — merge in order; GitHub will retarget bases automatically.

- **`tmdbImageUrl(path, TmdbImageSize)`** (`lib/core/utils/tmdb_image_url.dart`): one builder for all TMDB image URLs, replacing 15 hardcoded sites across 5 widths (w154/w342/w500/w780/original). Tolerates a missing leading slash, which fixes `movie_result_list`'s `w154//` double-slash URL. Phase 5's `cacheWidth` work will hang off this helper.
- **`ReviewsBottomSheet.show(context)`**: single opener; ThoughtsScreen and ReviewsFloatingButton carried byte-identical copies.
- **`SheetAppBar({title?, onCancel, onDone, backgroundColor?})`** (`lib/shared_widgets/sheet_app_bar.dart`): replaces the 3 copy-pasted Cancel/title/Done app bars in ThoughtsScreen, ScenesSelectSheet, CaptionEditor.
- **CustomToast**: `init` folded into `_show` (re-inits `FToast` from the passed context on every call); `showError`/`showWarning` now take `context`; `showError` gains optional `gravity` (`ToastGravity` re-exported so call sites don't import fluttertoast). All 11 `CustomToast.init` sites deleted.
- **Error surfaces unified**: `create_user.dart`'s raw `Fluttertoast` (keeps `ToastGravity.TOP` so validation errors stay above the keyboard) and `settings.dart`'s `SnackBar`s now go through CustomToast.
- **One screen-tracking idiom**: every screen wraps its build root in `ScreenViewTracker`; the `logScreenView()`-in-`initState` variant is gone. `ThoughtsScreen` no longer logs a screen view at all — it's a section of the Journaling flow and inflated screen counts.

CLAUDE.md updated for all changed surfaces; stale `themes.dart` StatusColors rationale fixed.

## Verification
- `flutter analyze`: No issues found.
- `flutter test`: 332 passed, 0 failed (includes updated `custom_toast_test.dart`).

Remaining in ISA-11: item 4 (dark-surface palette naming) and item 5 (file splits) — next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)