### PR TITLE
perf: value equality on state classes + .select() at whole-state watch sites (ISA-12, PR 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ The app follows a feature-based architecture where each feature is self-containe
 
 - **quesgen/** - AI review fetching service for movie reviews from external sources
   - `review.dart` - Review data model with `text` and `source` fields (sources: "letterboxd", "reddit")
-  - `controller.dart` - Review generation logic (QuesgenController, QuesgenState)
+  - `controller.dart` - Review generation logic (QuesgenController, QuesgenState). Also exports `toBackendLocaleTag()`, a top-level public function (public for testability, like `validateUsername`) converting the OS `Locale` to the BCP 47 tag the backend accepts — drops script subtags (`zh-Hant-TW` → `zh-TW`)
   - `provider.dart` - Riverpod provider
   - `api.dart` - API integration (GET `/generate/{movieId}`) returning `{ reviews: [{ text, source }] }`
 
@@ -147,6 +147,9 @@ Uses **Riverpod** for state management:
 - Controllers use Riverpod notifiers for complex state logic
 - Follow patterns: `Provider` for computed values, `NotifierProvider` for simple and complex state, `FutureProvider`/`AsyncNotifierProvider` for async operations
 - Note: Riverpod 3.x removed `StateProvider` — use a `Notifier` with a `set()` method instead (see `JournalModeNotifier` for pattern)
+- **State classes carry value equality.** `JournalState`, `JournalsState`, `SearchMovieState`, `QuesgenState`, `MovieImagesState` and their element models (`SceneItem`, `Emotion`, `Review`, `BriefMovie`, `MovieImage`) implement hand-rolled `==`/`hashCode` (deliberately no freezed/codegen). Riverpod's default `updateShouldNotify` compares with `==`, so a no-op `state = state.copyWith(...)` no longer notifies listeners. **Adding a field to one of these classes means updating its `==`/`hashCode` too** — the equality groups in the mirrored test files will catch a missed field only if you extend them.
+- `JournalState` is immutable (all fields `final`). Its public constructor is a factory so a defaulted `updatedAt` equals the *resolved* `createdAt` (identical `Jiffy`, not a second `Jiffy.now()`).
+- Prefer `ref.watch(provider.select((s) => s.field))` when a widget uses one or two fields of a larger state — done in `thoughts_editor.dart`, `scenes_selector.dart`, `caption_editor.dart`. Note `.select()` on a `List` field compares by list *identity*, which works because `copyWith` preserves untouched list instances.
 
 ### Data Flow
 

--- a/lib/features/emotion/emotion.dart
+++ b/lib/features/emotion/emotion.dart
@@ -10,6 +10,19 @@ class Emotion {
     required this.group,
     required this.energyLevel,
   });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Emotion &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          group == other.group &&
+          energyLevel == other.energyLevel;
+
+  @override
+  int get hashCode => Object.hash(id, name, group, energyLevel);
 }
 
 enum EmotionType {

--- a/lib/features/journal/controllers/journal.dart
+++ b/lib/features/journal/controllers/journal.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:jiffy/jiffy.dart';
 import 'package:movie_journal/analytics_manager.dart';
@@ -43,37 +44,73 @@ class SceneItem {
       caption: caption ?? this.caption,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SceneItem &&
+          runtimeType == other.runtimeType &&
+          path == other.path &&
+          caption == other.caption;
+
+  @override
+  int get hashCode => Object.hash(path, caption);
 }
 
 class JournalState {
-  String id = '';
-  int tmdbId = 0;
-  String movieTitle = '';
-  String moviePoster = '';
-  List<Emotion> emotions = [];
-  List<SceneItem> selectedScenes = [];
-  List<Review> selectedRefs = [];
-  String thoughts = '';
-  late Jiffy createdAt;
-  late Jiffy updatedAt;
+  final String id;
+  final int tmdbId;
+  final String movieTitle;
+  final String moviePoster;
+  final List<Emotion> emotions;
+  final List<SceneItem> selectedScenes;
+  final List<Review> selectedRefs;
+  final String thoughts;
+  final Jiffy createdAt;
+  final Jiffy updatedAt;
 
-  JournalState({
+  // A factory so updatedAt can default to the *resolved* createdAt — with a
+  // plain initializer list both would get their own Jiffy.now() and drift by
+  // a few microseconds.
+  factory JournalState({
     String? id,
-    this.tmdbId = 0,
-    this.movieTitle = '',
-    this.moviePoster = '',
-    this.emotions = const [],
-    this.selectedScenes = const [],
+    int tmdbId = 0,
+    String movieTitle = '',
+    String moviePoster = '',
+    List<Emotion> emotions = const [],
+    List<SceneItem> selectedScenes = const [],
     List<Review>? selectedRefs,
-    this.thoughts = '',
+    String thoughts = '',
     Jiffy? createdAt,
     Jiffy? updatedAt,
   }) {
-    this.id = id ?? Uuid().v4();
-    this.selectedRefs = selectedRefs ?? [];
-    this.createdAt = createdAt ?? Jiffy.now();
-    this.updatedAt = updatedAt ?? this.createdAt;
+    final resolvedCreatedAt = createdAt ?? Jiffy.now();
+    return JournalState._(
+      id: id ?? Uuid().v4(),
+      tmdbId: tmdbId,
+      movieTitle: movieTitle,
+      moviePoster: moviePoster,
+      emotions: emotions,
+      selectedScenes: selectedScenes,
+      selectedRefs: selectedRefs ?? [],
+      thoughts: thoughts,
+      createdAt: resolvedCreatedAt,
+      updatedAt: updatedAt ?? resolvedCreatedAt,
+    );
   }
+
+  JournalState._({
+    required this.id,
+    required this.tmdbId,
+    required this.movieTitle,
+    required this.moviePoster,
+    required this.emotions,
+    required this.selectedScenes,
+    required this.selectedRefs,
+    required this.thoughts,
+    required this.createdAt,
+    required this.updatedAt,
+  });
 
   JournalState copyWith({
     String? id,
@@ -100,6 +137,39 @@ class JournalState {
       updatedAt: updatedAt ?? this.updatedAt,
     );
   }
+
+  // Value equality: Riverpod's default updateShouldNotify compares with ==,
+  // so equal states produced by no-op copyWith calls stop notifying
+  // listeners, and .select() on list fields works as expected.
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is JournalState &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          tmdbId == other.tmdbId &&
+          movieTitle == other.movieTitle &&
+          moviePoster == other.moviePoster &&
+          listEquals(emotions, other.emotions) &&
+          listEquals(selectedScenes, other.selectedScenes) &&
+          listEquals(selectedRefs, other.selectedRefs) &&
+          thoughts == other.thoughts &&
+          createdAt == other.createdAt &&
+          updatedAt == other.updatedAt;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        tmdbId,
+        movieTitle,
+        moviePoster,
+        Object.hashAll(emotions),
+        Object.hashAll(selectedScenes),
+        Object.hashAll(selectedRefs),
+        thoughts,
+        createdAt,
+        updatedAt,
+      );
 
   Map<String, dynamic> toMap() {
     return {

--- a/lib/features/journal/controllers/journals.dart
+++ b/lib/features/journal/controllers/journals.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:movie_journal/analytics_manager.dart';
 import 'package:movie_journal/features/journal/controllers/journal.dart';
@@ -12,6 +13,16 @@ class JournalsState {
   JournalsState copyWith({List<JournalState>? journals}) {
     return JournalsState(journals: journals ?? this.journals);
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is JournalsState &&
+          runtimeType == other.runtimeType &&
+          listEquals(journals, other.journals);
+
+  @override
+  int get hashCode => Object.hashAll(journals);
 }
 
 // AsyncNotifier for loading journals from Supabase

--- a/lib/features/journal/screens/caption_editor.dart
+++ b/lib/features/journal/screens/caption_editor.dart
@@ -101,7 +101,9 @@ class _CaptionEditorState extends ConsumerState<CaptionEditor> {
 
   @override
   Widget build(BuildContext context) {
-    final selectedScenes = ref.watch(journalControllerProvider).selectedScenes;
+    final selectedScenes = ref.watch(
+      journalControllerProvider.select((j) => j.selectedScenes),
+    );
 
     return SizedBox(
       height: MediaQuery.of(context).size.height,

--- a/lib/features/journal/widgets/scenes_selector.dart
+++ b/lib/features/journal/widgets/scenes_selector.dart
@@ -298,8 +298,10 @@ class _ScenesSelectorState extends ConsumerState<ScenesSelector> {
   @override
   Widget build(BuildContext context) {
     final movieImagesAsync = ref.watch(movieImagesControllerProvider);
-    final journal = ref.watch(journalControllerProvider);
-    final selectedScenes = journal.selectedScenes;
+    // Only the scenes matter here; thoughts/emotion edits shouldn't rebuild.
+    final selectedScenes = ref.watch(
+      journalControllerProvider.select((j) => j.selectedScenes),
+    );
 
     return Column(
       spacing: 16,

--- a/lib/features/journal/widgets/thoughts_editor.dart
+++ b/lib/features/journal/widgets/thoughts_editor.dart
@@ -10,8 +10,14 @@ class ThoughtsEditor extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final journal = ref.watch(journalControllerProvider);
-    final selectedRefs = journal.selectedRefs;
+    // Field-level selects: this widget only cares about thoughts and
+    // selectedRefs, so scene/emotion edits shouldn't rebuild it.
+    final thoughts = ref.watch(
+      journalControllerProvider.select((j) => j.thoughts),
+    );
+    final selectedRefs = ref.watch(
+      journalControllerProvider.select((j) => j.selectedRefs),
+    );
     return InkWell(
       splashColor: Colors.transparent,
       onTap:
@@ -40,11 +46,9 @@ class ThoughtsEditor extends ConsumerWidget {
           Container(
             padding: EdgeInsets.symmetric(vertical: 8),
             child: Text(
-              journal.thoughts.isNotEmpty
-                  ? journal.thoughts
-                  : 'Enter your text here...',
+              thoughts.isNotEmpty ? thoughts : 'Enter your text here...',
               style:
-                  journal.thoughts.isNotEmpty
+                  thoughts.isNotEmpty
                       ? GoogleFonts.inter(
                         fontSize: 14,
                         fontWeight: FontWeight.w400,

--- a/lib/features/movie/controllers/movie_images_controller.dart
+++ b/lib/features/movie/controllers/movie_images_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:movie_journal/features/movie/data/models/movie_image.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
@@ -70,4 +71,20 @@ class MovieImagesState {
       backdrops: backdrops ?? this.backdrops,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MovieImagesState &&
+          runtimeType == other.runtimeType &&
+          listEquals(posters, other.posters) &&
+          listEquals(logos, other.logos) &&
+          listEquals(backdrops, other.backdrops);
+
+  @override
+  int get hashCode => Object.hash(
+        Object.hashAll(posters),
+        Object.hashAll(logos),
+        Object.hashAll(backdrops),
+      );
 }

--- a/lib/features/movie/controllers/search_movie_controller.dart
+++ b/lib/features/movie/controllers/search_movie_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:movie_journal/features/movie/data/data_sources/movie_api.dart';
 import 'package:movie_journal/features/movie/data/models/brief_movie.dart';
@@ -41,6 +42,21 @@ class SearchMovieState {
               : SearchMovieMode.search),
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SearchMovieState &&
+          runtimeType == other.runtimeType &&
+          listEquals(movies, other.movies) &&
+          query == other.query &&
+          page == other.page &&
+          hasMore == other.hasMore &&
+          mode == other.mode;
+
+  @override
+  int get hashCode =>
+      Object.hash(Object.hashAll(movies), query, page, hasMore, mode);
 }
 
 bool movieIntegrityChecker(BriefMovie movie) =>

--- a/lib/features/movie/data/models/brief_movie.dart
+++ b/lib/features/movie/data/models/brief_movie.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 class BriefMovie {
   final int id;
   final bool adult;
@@ -55,4 +57,44 @@ class BriefMovie {
             ? json['release_date'].substring(0, 4)
             : 'Unknown',
   );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BriefMovie &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          adult == other.adult &&
+          title == other.title &&
+          originalTitle == other.originalTitle &&
+          originalLanguage == other.originalLanguage &&
+          overview == other.overview &&
+          backdropPath == other.backdropPath &&
+          posterPath == other.posterPath &&
+          listEquals(genreIds, other.genreIds) &&
+          popularity == other.popularity &&
+          releaseDate == other.releaseDate &&
+          video == other.video &&
+          voteAverage == other.voteAverage &&
+          voteCount == other.voteCount &&
+          year == other.year;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        adult,
+        title,
+        originalTitle,
+        originalLanguage,
+        overview,
+        backdropPath,
+        posterPath,
+        genreIds == null ? null : Object.hashAll(genreIds!),
+        popularity,
+        releaseDate,
+        video,
+        voteAverage,
+        voteCount,
+        year,
+      );
 }

--- a/lib/features/movie/data/models/movie_image.dart
+++ b/lib/features/movie/data/models/movie_image.dart
@@ -28,4 +28,28 @@ class MovieImage {
       voteCount: json['vote_count'],
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MovieImage &&
+          runtimeType == other.runtimeType &&
+          filePath == other.filePath &&
+          aspectRatio == other.aspectRatio &&
+          height == other.height &&
+          width == other.width &&
+          iso6391 == other.iso6391 &&
+          voteAverage == other.voteAverage &&
+          voteCount == other.voteCount;
+
+  @override
+  int get hashCode => Object.hash(
+        filePath,
+        aspectRatio,
+        height,
+        width,
+        iso6391,
+        voteAverage,
+        voteCount,
+      );
 }

--- a/lib/features/quesgen/controller.dart
+++ b/lib/features/quesgen/controller.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:movie_journal/features/quesgen/api.dart';
 import 'package:movie_journal/features/quesgen/review.dart';
@@ -28,6 +29,18 @@ class QuesgenState {
       isError: isError ?? this.isError,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is QuesgenState &&
+          runtimeType == other.runtimeType &&
+          listEquals(reviews, other.reviews) &&
+          isLoading == other.isLoading &&
+          isError == other.isError;
+
+  @override
+  int get hashCode => Object.hash(Object.hashAll(reviews), isLoading, isError);
 }
 
 class QuesgenController extends Notifier<QuesgenState> {
@@ -41,7 +54,7 @@ class QuesgenController extends Notifier<QuesgenState> {
   }) async {
     state = state.copyWith(isLoading: true);
     try {
-      final locale = _toBackendLocaleTag(PlatformDispatcher.instance.locale);
+      final locale = toBackendLocaleTag(PlatformDispatcher.instance.locale);
       final newReviews = await ref
           .read(quesgenApiProvider)
           .generateReviews(
@@ -69,7 +82,10 @@ class QuesgenController extends Notifier<QuesgenState> {
 ///   code already encodes the script (TW/HK -> Traditional, CN -> Simplified).
 /// - Returns `null` when the language code is missing so the caller can
 ///   omit `?lang=` and let the server apply its own default.
-String? _toBackendLocaleTag(Locale locale) {
+///
+/// Top-level and public for testability (same pattern as `validateUsername`
+/// in create_user.dart).
+String? toBackendLocaleTag(Locale locale) {
   final language = locale.languageCode.trim();
   if (language.isEmpty) return null;
   final country = locale.countryCode;

--- a/test/features/emotion/emotion_test.dart
+++ b/test/features/emotion/emotion_test.dart
@@ -53,4 +53,42 @@ void main() {
       expect(found.value.group, 'Uplifting');
     });
   });
+
+  group('Emotion value equality', () {
+    // Built with `final` (not const) so instances are not canonicalized and
+    // the == override is actually exercised.
+    test('same fields → equal, same hashCode', () {
+      final a = Emotion(
+        id: 'joyful',
+        name: 'Joyful',
+        group: 'Uplifting',
+        energyLevel: 'high',
+      );
+      final b = Emotion(
+        id: 'joyful',
+        name: 'Joyful',
+        group: 'Uplifting',
+        energyLevel: 'high',
+      );
+      expect(identical(a, b), isFalse);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different id → not equal', () {
+      final a = Emotion(
+        id: 'joyful',
+        name: 'Joyful',
+        group: 'Uplifting',
+        energyLevel: 'high',
+      );
+      final b = Emotion(
+        id: 'funny',
+        name: 'Joyful',
+        group: 'Uplifting',
+        energyLevel: 'high',
+      );
+      expect(a, isNot(equals(b)));
+    });
+  });
 }

--- a/test/features/journal/controllers/journal_test.dart
+++ b/test/features/journal/controllers/journal_test.dart
@@ -420,4 +420,161 @@ void main() {
       expect(state.thoughts, 'My deep thoughts about the movie');
     });
   });
+
+  // ── Value equality (ISA-12 item 1) ─────────────────────────────────
+
+  group('SceneItem value equality', () {
+    test('same path + caption → equal, same hashCode', () {
+      final a = SceneItem(path: '/scene.jpg', caption: 'wow');
+      final b = SceneItem(path: '/scene.jpg', caption: 'wow');
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('null captions on both sides → equal', () {
+      expect(SceneItem(path: '/s.jpg'), equals(SceneItem(path: '/s.jpg')));
+    });
+
+    test('different caption → not equal', () {
+      final a = SceneItem(path: '/scene.jpg', caption: 'wow');
+      final b = SceneItem(path: '/scene.jpg', caption: 'meh');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('caption set vs null → not equal', () {
+      final a = SceneItem(path: '/scene.jpg', caption: 'wow');
+      final b = SceneItem(path: '/scene.jpg');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('different path → not equal', () {
+      expect(
+        SceneItem(path: '/a.jpg'),
+        isNot(equals(SceneItem(path: '/b.jpg'))),
+      );
+    });
+  });
+
+  group('JournalState value equality', () {
+    JournalState buildJournal() {
+      final t = Jiffy.parse('2026-07-30 10:00:00');
+      return makeJournal(
+        id: 'fixed-id',
+        tmdbId: 550,
+        movieTitle: 'Fight Club',
+        thoughts: 'great',
+        emotions: [emotionList[EmotionType.joyful]!],
+        selectedScenes: [SceneItem(path: '/s.jpg', caption: 'c')],
+        selectedRefs: [Review(text: 'r', source: 'reddit')],
+        createdAt: t,
+        updatedAt: t,
+      );
+    }
+
+    test('same field values → equal, same hashCode', () {
+      final a = buildJournal();
+      final b = buildJournal();
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('lists are compared by value, not identity', () {
+      final a = buildJournal();
+      final b = buildJournal();
+      expect(identical(a.selectedScenes, b.selectedScenes), isFalse);
+      expect(identical(a.selectedRefs, b.selectedRefs), isFalse);
+      expect(a, equals(b));
+    });
+
+    test('copyWith with no args → equal to original', () {
+      final a = buildJournal();
+      expect(a.copyWith(), equals(a));
+    });
+
+    test('each field difference breaks equality', () {
+      final a = buildJournal();
+      expect(a.copyWith(id: 'other'), isNot(equals(a)));
+      expect(a.copyWith(tmdbId: 551), isNot(equals(a)));
+      expect(a.copyWith(movieTitle: 'Se7en'), isNot(equals(a)));
+      expect(a.copyWith(moviePoster: '/x.jpg'), isNot(equals(a)));
+      expect(a.copyWith(thoughts: 'meh'), isNot(equals(a)));
+      expect(
+        a.copyWith(emotions: [emotionList[EmotionType.angry]!]),
+        isNot(equals(a)),
+      );
+      expect(
+        a.copyWith(selectedScenes: [SceneItem(path: '/other.jpg')]),
+        isNot(equals(a)),
+      );
+      expect(
+        a.copyWith(selectedRefs: [Review(text: 'x', source: 'letterboxd')]),
+        isNot(equals(a)),
+      );
+      expect(
+        a.copyWith(createdAt: Jiffy.parse('2020-01-01 00:00:00')),
+        isNot(equals(a)),
+      );
+      expect(
+        a.copyWith(updatedAt: Jiffy.parse('2020-01-01 00:00:00')),
+        isNot(equals(a)),
+      );
+    });
+  });
+
+  group('notification behavior with value equality', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('assigning an equal state does not notify listeners', () {
+      var notifications = 0;
+      container.listen(journalControllerProvider, (_, _) => notifications++);
+      final controller = container.read(journalControllerProvider.notifier);
+
+      controller.setThoughts('hello');
+      expect(notifications, 1);
+
+      // Same value again: copyWith produces an equal state, and Riverpod's
+      // default updateShouldNotify compares with ==, so no notification.
+      controller.setThoughts('hello');
+      expect(notifications, 1);
+    });
+
+    test('select(selectedScenes) ignores unrelated field changes', () {
+      var notifications = 0;
+      container.listen(
+        journalControllerProvider.select((j) => j.selectedScenes),
+        (_, _) => notifications++,
+      );
+      final controller = container.read(journalControllerProvider.notifier);
+
+      controller.setThoughts('unrelated');
+      controller.setMovieTitle('unrelated too');
+      expect(notifications, 0);
+
+      controller.addScene('/s.jpg');
+      expect(notifications, 1);
+    });
+
+    test('select(thoughts) ignores scene changes', () {
+      var notifications = 0;
+      container.listen(
+        journalControllerProvider.select((j) => j.thoughts),
+        (_, _) => notifications++,
+      );
+      final controller = container.read(journalControllerProvider.notifier);
+
+      controller.addScene('/s.jpg');
+      expect(notifications, 0);
+
+      controller.setThoughts('now');
+      expect(notifications, 1);
+    });
+  });
 }

--- a/test/features/journal/controllers/journals_test.dart
+++ b/test/features/journal/controllers/journals_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jiffy/jiffy.dart';
 import 'package:movie_journal/features/journal/controllers/journals.dart';
 
 import '../../../helpers/test_journal.dart';
@@ -43,6 +44,44 @@ void main() {
 
       expect(original.journals.length, 1);
       expect(updated.journals.length, 2);
+    });
+  });
+
+  group('JournalsState value equality', () {
+    test('same journals (by value) → equal, same hashCode', () {
+      final t = Jiffy.parse('2026-07-30 10:00:00');
+      final a = JournalsState(
+        journals: [makeJournal(id: 'j1', createdAt: t, updatedAt: t)],
+      );
+      final b = JournalsState(
+        journals: [makeJournal(id: 'j1', createdAt: t, updatedAt: t)],
+      );
+      expect(identical(a.journals, b.journals), isFalse);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('empty states → equal', () {
+      expect(JournalsState(), equals(JournalsState()));
+    });
+
+    test('different journals → not equal', () {
+      final t = Jiffy.parse('2026-07-30 10:00:00');
+      final a = JournalsState(
+        journals: [makeJournal(id: 'j1', createdAt: t, updatedAt: t)],
+      );
+      final b = JournalsState(
+        journals: [makeJournal(id: 'j2', createdAt: t, updatedAt: t)],
+      );
+      expect(a, isNot(equals(b)));
+    });
+
+    test('different length → not equal', () {
+      final t = Jiffy.parse('2026-07-30 10:00:00');
+      final journal = makeJournal(id: 'j1', createdAt: t, updatedAt: t);
+      final a = JournalsState(journals: [journal]);
+      final b = JournalsState(journals: [journal, journal]);
+      expect(a, isNot(equals(b)));
     });
   });
 }

--- a/test/features/journal/widgets/journal_actions_test.dart
+++ b/test/features/journal/widgets/journal_actions_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:movie_journal/features/journal/widgets/journal_actions.dart';
+import 'package:movie_journal/features/share/screens/share_ticket_screen.dart';
+import 'package:movie_journal/features/share/screens/ticket_poster_picker_screen.dart';
+
+import '../../../helpers/test_journal.dart';
+import '../../../helpers/widget_test_setup.dart';
+
+void main() {
+  setUpAll(() {
+    setUpWidgetTests();
+    // TicketPosterPickerScreen fetches movie details/posters on mount; the
+    // TMDB client reads its token from dotenv at construction time.
+    dotenv.loadFromString(envString: 'TMDB_ACCESS_TOKEN=test-token');
+  });
+  tearDownAll(tearDownWidgetTests);
+
+  group('confirmDeleteJournal', () {
+    Future<void> pumpHost(
+      WidgetTester tester,
+      void Function(bool) onResult,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => TextButton(
+              onPressed: () async {
+                onResult(await confirmDeleteJournal(context));
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('shows the confirmation dialog', (tester) async {
+      await pumpHost(tester, (_) {});
+      expect(find.text('Delete Journal'), findsOneWidget);
+      expect(
+        find.text('Are you sure you want to delete this journal?'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('returns true when Delete is tapped', (tester) async {
+      bool? result;
+      await pumpHost(tester, (r) => result = r);
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+      expect(result, isTrue);
+    });
+
+    testWidgets('returns false when Cancel is tapped', (tester) async {
+      bool? result;
+      await pumpHost(tester, (r) => result = r);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(result, isFalse);
+    });
+
+    testWidgets('returns false when dismissed via the barrier', (tester) async {
+      bool? result;
+      await pumpHost(tester, (r) => result = r);
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+      expect(result, isFalse);
+    });
+  });
+
+  group('shareJournal', () {
+    testWidgets(
+      'pushes TicketPosterPickerScreen on a route tagged kShareFlowRouteName',
+      (tester) async {
+        final pushedRouteNames = <String?>[];
+        final observer = _RecordingNavigatorObserver(pushedRouteNames);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              navigatorObservers: [observer],
+              home: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () => shareJournal(context, makeJournal()),
+                  child: const Text('share'),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('share'));
+        // Bounded pumps: the picker shows an infinite skeleton shimmer while
+        // loading, so pumpAndSettle would never settle.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byType(TicketPosterPickerScreen), findsOneWidget);
+        expect(pushedRouteNames, contains(kShareFlowRouteName));
+      },
+    );
+  });
+}
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  _RecordingNavigatorObserver(this.pushedRouteNames);
+
+  final List<String?> pushedRouteNames;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushedRouteNames.add(route.settings.name);
+    super.didPush(route, previousRoute);
+  }
+}

--- a/test/features/movie/controllers/movie_images_controller_test.dart
+++ b/test/features/movie/controllers/movie_images_controller_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:movie_journal/features/movie/controllers/movie_images_controller.dart';
+import 'package:movie_journal/features/movie/data/models/movie_image.dart';
 import 'package:movie_journal/features/movie/movie_providers.dart';
 
 void main() {
@@ -49,5 +51,45 @@ void main() {
         );
       },
     );
+  });
+
+  group('MovieImagesState value equality', () {
+    MovieImage buildImage({String filePath = '/img.jpg'}) {
+      return MovieImage(
+        filePath: filePath,
+        aspectRatio: 1.778,
+        height: 1080,
+        width: 1920,
+        iso6391: null,
+        voteAverage: 5.0,
+        voteCount: 1,
+      );
+    }
+
+    test('same images (by value) → equal, same hashCode', () {
+      final a = MovieImagesState(
+        posters: [buildImage()],
+        logos: [],
+        backdrops: [buildImage(filePath: '/b.jpg')],
+      );
+      final b = MovieImagesState(
+        posters: [buildImage()],
+        logos: [],
+        backdrops: [buildImage(filePath: '/b.jpg')],
+      );
+      expect(identical(a.posters, b.posters), isFalse);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different backdrops → not equal', () {
+      final a = MovieImagesState(posters: [], logos: [], backdrops: []);
+      final b = MovieImagesState(
+        posters: [],
+        logos: [],
+        backdrops: [buildImage()],
+      );
+      expect(a, isNot(equals(b)));
+    });
   });
 }

--- a/test/features/movie/controllers/search_movie_controller_test.dart
+++ b/test/features/movie/controllers/search_movie_controller_test.dart
@@ -94,20 +94,82 @@ void main() {
     });
   });
 
-  group('SearchMovieController.loadMore', () {
-    // Regression test for ISA-9 bug 5: a pagination failure used to set a
-    // bare AsyncError, which dropped every already-loaded page from the state
-    // and made all later loadMore() calls bail at the `state.value == null`
-    // guard.
-    test('failure preserves loaded movies and stays retryable', () async {
-      final repo = _FakeMovieRepo();
+  group('SearchMovieState value equality', () {
+    test('same fields → equal, same hashCode', () {
+      final a = SearchMovieState(
+        movies: [BriefMovie.fromJson(makeBriefMovieJson())],
+        query: 'fight',
+        page: 2,
+        hasMore: true,
+        mode: SearchMovieMode.search,
+      );
+      final b = SearchMovieState(
+        movies: [BriefMovie.fromJson(makeBriefMovieJson())],
+        query: 'fight',
+        page: 2,
+        hasMore: true,
+        mode: SearchMovieMode.search,
+      );
+      expect(identical(a.movies, b.movies), isFalse);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('default states → equal', () {
+      expect(SearchMovieState(), equals(SearchMovieState()));
+    });
+
+    test('different movies → not equal', () {
+      final a = SearchMovieState(
+        movies: [BriefMovie.fromJson(makeBriefMovieJson(id: 1))],
+      );
+      final b = SearchMovieState(
+        movies: [BriefMovie.fromJson(makeBriefMovieJson(id: 2))],
+      );
+      expect(a, isNot(equals(b)));
+    });
+
+    test('different query → not equal', () {
+      final a = SearchMovieState(query: 'a', mode: SearchMovieMode.search);
+      final b = SearchMovieState(query: 'b', mode: SearchMovieMode.search);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('different page → not equal', () {
+      expect(
+        SearchMovieState(page: 1),
+        isNot(equals(SearchMovieState(page: 2))),
+      );
+    });
+
+    test('different hasMore → not equal', () {
+      expect(
+        SearchMovieState(hasMore: true),
+        isNot(equals(SearchMovieState(hasMore: false))),
+      );
+    });
+  });
+
+  group('SearchMovieController', () {
+    ProviderContainer containerWith(_FakeMovieRepo repo) {
       final container = ProviderContainer(
         overrides: [movieRepoProvider.overrideWithValue(repo)],
       );
       addTearDown(container.dispose);
-      // Riverpod 3 auto-disposes unlistened providers mid-await; keep the
-      // element alive (see Known Test Findings in CLAUDE.md).
+      // Riverpod 3 auto-disposes unlistened providers mid-flight; keep the
+      // element alive or `.future` never completes (see CLAUDE.md).
       container.listen(searchMovieControllerProvider, (_, _) {});
+      return container;
+    }
+
+    // Regression test for ISA-9 bug 5: a pagination failure used to set a
+    // bare AsyncError, which dropped every already-loaded page from the state
+    // and made all later loadMore() calls bail at the `state.value == null`
+    // guard.
+    test('loadMore() failure preserves loaded movies and stays retryable',
+        () async {
+      final repo = _FakeMovieRepo();
+      final container = containerWith(repo);
 
       final initial =
           await container.read(searchMovieControllerProvider.future);
@@ -131,6 +193,55 @@ void main() {
       final recovered = container.read(searchMovieControllerProvider);
       expect(recovered.hasError, isFalse);
       expect(recovered.value!.movies.length, greaterThan(initialCount));
+    });
+
+    test('build() loads the first popular page', () async {
+      final container = containerWith(_FakeMovieRepo());
+
+      final state = await container.read(searchMovieControllerProvider.future);
+
+      expect(state.movies.single.id, 1);
+      expect(state.page, 2);
+      expect(state.hasMore, isTrue);
+      expect(state.mode, SearchMovieMode.popular);
+    });
+
+    test('loadMore() appends the next page', () async {
+      final container = containerWith(_FakeMovieRepo());
+      await container.read(searchMovieControllerProvider.future);
+
+      await container
+          .read(searchMovieControllerProvider.notifier)
+          .loadMore();
+
+      final state = container.read(searchMovieControllerProvider).value!;
+      expect(state.movies.map((m) => m.id), [1, 2]);
+      expect(state.page, 3);
+    });
+
+    test('search() switches to search mode and resets paging', () async {
+      final container = containerWith(_FakeMovieRepo());
+      await container.read(searchMovieControllerProvider.future);
+
+      await container
+          .read(searchMovieControllerProvider.notifier)
+          .search('fight');
+
+      final state = container.read(searchMovieControllerProvider).value!;
+      expect(state.mode, SearchMovieMode.search);
+      expect(state.query, 'fight');
+      expect(state.page, 2);
+    });
+
+    test('failed popular reload surfaces AsyncError', () async {
+      final repo = _FakeMovieRepo();
+      final container = containerWith(repo);
+      await container.read(searchMovieControllerProvider.future);
+
+      repo.failPopular = true;
+      await container.read(searchMovieControllerProvider.notifier).search('');
+
+      expect(container.read(searchMovieControllerProvider).hasError, isTrue);
     });
   });
 }

--- a/test/features/movie/data/models/brief_movie_test.dart
+++ b/test/features/movie/data/models/brief_movie_test.dart
@@ -59,4 +59,31 @@ void main() {
       expect(movie.voteCount, isNull);
     });
   });
+
+  group('BriefMovie value equality', () {
+    test('same JSON → equal, same hashCode', () {
+      final a = BriefMovie.fromJson(makeBriefMovieJson());
+      final b = BriefMovie.fromJson(makeBriefMovieJson());
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('genreIds compared by value, not identity', () {
+      final a = BriefMovie.fromJson(makeBriefMovieJson(genreIds: [18, 53]));
+      final b = BriefMovie.fromJson(makeBriefMovieJson(genreIds: [18, 53]));
+      expect(a, equals(b));
+    });
+
+    test('different id → not equal', () {
+      final a = BriefMovie.fromJson(makeBriefMovieJson(id: 1));
+      final b = BriefMovie.fromJson(makeBriefMovieJson(id: 2));
+      expect(a, isNot(equals(b)));
+    });
+
+    test('different title → not equal', () {
+      final a = BriefMovie.fromJson(makeBriefMovieJson(title: 'A'));
+      final b = BriefMovie.fromJson(makeBriefMovieJson(title: 'B'));
+      expect(a, isNot(equals(b)));
+    });
+  });
 }

--- a/test/features/movie/data/models/movie_image_test.dart
+++ b/test/features/movie/data/models/movie_image_test.dart
@@ -23,4 +23,32 @@ void main() {
       expect(image.voteCount, 4);
     });
   });
+
+  group('MovieImage value equality', () {
+    MovieImage buildImage({String filePath = '/abc123.jpg'}) {
+      return MovieImage(
+        filePath: filePath,
+        aspectRatio: 0.667,
+        height: 3000,
+        width: 2000,
+        iso6391: 'en',
+        voteAverage: 5.312,
+        voteCount: 4,
+      );
+    }
+
+    test('same fields → equal, same hashCode', () {
+      final a = buildImage();
+      final b = buildImage();
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different filePath → not equal', () {
+      expect(
+        buildImage(filePath: '/a.jpg'),
+        isNot(equals(buildImage(filePath: '/b.jpg'))),
+      );
+    });
+  });
 }

--- a/test/features/quesgen/controller_test.dart
+++ b/test/features/quesgen/controller_test.dart
@@ -1,0 +1,97 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:movie_journal/features/quesgen/controller.dart';
+import 'package:movie_journal/features/quesgen/review.dart';
+
+void main() {
+  group('QuesgenState value equality', () {
+    test('same fields → equal, same hashCode', () {
+      final a = QuesgenState(
+        reviews: [Review(text: 'Great', source: 'reddit')],
+        isLoading: false,
+        isError: false,
+      );
+      final b = QuesgenState(
+        reviews: [Review(text: 'Great', source: 'reddit')],
+        isLoading: false,
+        isError: false,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('equal even when review lists are distinct instances', () {
+      final a = QuesgenState(
+        reviews: [Review(text: 'A', source: 'letterboxd')],
+        isLoading: true,
+        isError: false,
+      );
+      final b = QuesgenState(
+        reviews: [Review(text: 'A', source: 'letterboxd')],
+        isLoading: true,
+        isError: false,
+      );
+      expect(identical(a.reviews, b.reviews), isFalse);
+      expect(a, equals(b));
+    });
+
+    test('different reviews → not equal', () {
+      final a = QuesgenState(reviews: [], isLoading: false, isError: false);
+      final b = QuesgenState(
+        reviews: [Review(text: 'B', source: 'reddit')],
+        isLoading: false,
+        isError: false,
+      );
+      expect(a, isNot(equals(b)));
+    });
+
+    test('different isLoading → not equal', () {
+      final a = QuesgenState(reviews: [], isLoading: false, isError: false);
+      final b = a.copyWith(isLoading: true);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('different isError → not equal', () {
+      final a = QuesgenState(reviews: [], isLoading: false, isError: false);
+      final b = a.copyWith(isError: true);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('copyWith with no args → equal to original', () {
+      final a = QuesgenState(
+        reviews: [Review(text: 'X', source: 'reddit')],
+        isLoading: false,
+        isError: true,
+      );
+      expect(a.copyWith(), equals(a));
+    });
+  });
+
+  group('toBackendLocaleTag', () {
+    test('language + country → "lang-COUNTRY"', () {
+      expect(toBackendLocaleTag(const Locale('en', 'US')), 'en-US');
+    });
+
+    test('language only → language', () {
+      expect(toBackendLocaleTag(const Locale('ja')), 'ja');
+    });
+
+    test('empty country → language only', () {
+      expect(toBackendLocaleTag(const Locale('en', '')), 'en');
+    });
+
+    test('script subtag is dropped (zh-Hant-TW → zh-TW)', () {
+      const locale = Locale.fromSubtags(
+        languageCode: 'zh',
+        scriptCode: 'Hant',
+        countryCode: 'TW',
+      );
+      expect(toBackendLocaleTag(locale), 'zh-TW');
+    });
+
+    test('blank language → null so caller omits ?lang=', () {
+      expect(toBackendLocaleTag(const Locale(' ')), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 5 (ISA-12) item 1 + test backfill — first of the planned small PRs.

- Hand-rolled `==`/`hashCode` (no codegen, matching the repo's mocktail/no-codegen convention) on the five state classes — `JournalState`, `JournalsState`, `SearchMovieState`, `QuesgenState`, `MovieImagesState` — and their element classes `SceneItem`, `Emotion`, `BriefMovie`, `MovieImage`.
- `JournalState` fields are now `final`. A factory constructor preserves the existing `updatedAt`-defaults-to-resolved-`createdAt` semantics (previously done with `late` fields).
- `.select()` applied at the three whole-state watch sites named in the spec: `thoughts_editor.dart`, `scenes_selector.dart`, `caption_editor.dart`. With value equality in place, Riverpod's default `updateShouldNotify` (which compares with `==`) now suppresses no-op notifications — verified against riverpod 3.0.3 source and pinned by new notification-behavior tests.
- Test backfill from the issue: new `journal_actions_test.dart` (confirm-delete dialog paths, share-flow route tagging), `toBackendLocaleTag` made public (same precedent as `validateUsername`) + tests, and `SearchMovieController` fake-repo tests as groundwork for the PR-2 race guards.

Tests were written first; the 6 new equality/notification tests were red before implementation.

## Verification

- `flutter analyze`: no issues
- `flutter test`: 394 passed, 0 failed (includes the ISA-9 `loadMore` regression test, which was merged with the new controller-test scaffolding during rebase onto current main)

## Notes

- No dependency changes; `pubspec.lock` untouched.
- Remaining Phase 5 items (search race guards, `.family` providers, image decode, memoization) land as separate PRs on this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)