### PR TITLE
ci: grant the Claude workflows write on pull-requests and issues (ISA-26)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,10 +19,13 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    # write on pull-requests + issues is what lets the action post its review and
+    # inline comments. With read, the run still reports success but every write is
+    # denied and the findings are discarded with the runner (ISA-26).
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -39,6 +42,11 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # Echo the final report into the workflow log as well. The action defaults
+          # this to false, which is why the ISA-26 runs left no trace anywhere once
+          # the PR write was denied. Keep it on: it is the fallback that makes a
+          # future posting failure visible instead of silent.
+          display_report: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,10 +18,13 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    # Same defect as claude-code-review.yml (ISA-26): this workflow answers @claude
+    # mentions by writing a comment, so read-only pull-requests/issues means the
+    # reply is silently dropped.
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
Fixes the green rubber stamp on `claude-review`.

> **Correction:** an earlier version of this description claimed the PR verifies itself. It does not — see Verification. The Claude GitHub App refuses to run on any PR that edits its own workflow file, so end-to-end confirmation has to happen on the *next* PR after this merges.

## Root cause

Both workflows declared `pull-requests: read` / `issues: read`. `anthropics/claude-code-action` needs **write** on both to post a review or inline comments. With read, every write is denied but the job still exits 0 — a green check carrying no information.

Measured on PR #39's run (`30617927714`):

```
GITHUB_TOKEN Permissions
  Contents: read
  Issues: read
  Metadata: read
  PullRequests: read
...
  "duration_ms": 947185,
  "total_cost_usd": 12.06,
  "permission_denials_count": 57
No buffered inline comments
```

Across every PR the workflow has ever run on — #33, #34, #35, #36, #38, #39 — there are **zero comments and zero reviews from `claude[bot]`**. The only PR comment in the repo is a human one on #38.

## Changes

1. `pull-requests: write` + `issues: write` on `claude-code-review.yml`. `contents` stays `read` — the reviewer has no reason to push.
2. `display_report: true`. The action defaults it to `false`, which is why the runs left no trace in the log either — the report went only to `/home/runner/work/_temp/claude-execution-output.json` and died with the runner. With it on, a future posting failure is visible instead of silent.
3. **Same fix in `claude.yml`** (adjacent, outside the original issue scope, called out deliberately): it answers `@claude` mentions by writing a comment, so it has the identical defect and has been silently dropping every reply. Happy to split this out if you'd rather.

## Verification

**Confirmed:**

- Both files parse; resolved permissions asserted via `js-yaml`:
  - `claude-code-review.yml` → `{contents: read, pull-requests: write, issues: write, id-token: write}`
  - `claude.yml` → `{contents: read, pull-requests: write, issues: write, id-token: write, actions: read}`
- The grant takes effect on a real run. This PR's run (`30619343832`) reports:
  ```
  GITHUB_TOKEN Permissions
    Contents: read
    Issues: write
    Metadata: read
    PullRequests: write
  ```
  This also settles a risk I could not check up front — the repo's default-workflow-permissions setting is not readable with my token, but it clearly does not cap an explicit `permissions:` block.
- `display_report` is a real input and was accepted (`DISPLAY_REPORT: true` in the run env).

**Not confirmed — a review body actually landing.** This PR's run stopped before invoking Claude at all:

```
##[warning]Skipping action due to workflow validation: Workflow validation failed.
The workflow file must exist and have identical content to the version on the
repository's default branch.
Error is not retryable, giving up immediately
Exiting due to workflow validation skip
##[end-action id=claude-review.run;outcome=success;conclusion=success]
```

That guard is Anthropic's and it is correct — it stops a PR from rewriting the reviewer's own workflow and exfiltrating secrets. But note the last line: **it exits `success`.** So this is a second, independent rubber-stamp path, one this PR cannot fix: *any PR touching `.github/workflows/` gets a green `claude-review` that never ran.* Worth knowing when judging such a PR on its check.

**How to finish verification:** merge this, then push any commit to open PR #39 (`perf/isa-18-cached-network-image`, MERGEABLE, does not touch workflows). Its `synchronize` run will use a workflow file matching `main`, validation will pass, and a review from `claude[bot]` should appear on #39 — which also surfaces what the reviewer has been silently reporting on the perf PRs.

No app code touched, so no Flutter test impact.

## Not in scope

Whether ~$12 and ~16 min per PR is worth it at this cadence is the CEO's call, tracked on ISA-26. If the answer is no, the levers are a `paths:` filter or a label trigger.
