### PR TITLE
fix(ios): silence system-keyboard constraint log spam (ISA-40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,34 @@ Feature lives under `lib/features/share/`. Flow: callers → `TicketPosterPicker
 - Access emotions via `emotionList` map using `EmotionType` enum keys
 - Users can select multiple emotions per journal entry
 
+### iOS console noise
+
+`AppDelegate.silenceSystemKeyboardConstraintLogs()` sets the private
+`_UIConstraintBasedLayoutLogUnsatisfiable` default to `false` **in debug builds only**.
+
+- **What it silences (ISA-40):** every keyboard presentation — most visibly opening
+  `CaptionEditor` from a selected scene, which auto-focuses a `TextField` in
+  `initState` — dumped several "Unable to simultaneously satisfy constraints" blocks
+  naming `TUIPredictionViewCell` / `TUICandidateGradientContentLabel`. Those are
+  Apple's TextInputUI framework, which loads **into this process** to lay out the
+  keyboard's candidate / QuickType bar; the broken constraint set is Apple's
+  (a prediction cell of width 0 whose label is pinned 6pt from both edges). No Flutter
+  widget can produce or prevent it — Flutter draws layers, not constrained `UIView`s.
+- **Rejected alternative:** `autocorrect: false` / `enableSuggestions: false` on the
+  caption field suppresses the QuickType bar on Latin keyboards, but it is a real UX
+  regression, and it does nothing for the CJK candidate bar (which is *how you type* —
+  and the reporter's keyboard). Don't degrade input to quiet a log.
+- **Cost:** it mutes *all* unsatisfiable-constraint logging, including any from native
+  plugin UI (share sheets, sign-in). To get it back for one run, pass
+  `-_UIConstraintBasedLayoutLogUnsatisfiable YES` in the Xcode scheme's launch
+  arguments — `NSArgumentDomain` outranks what `AppDelegate` writes.
+- **`SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG"` on the Runner target's
+  Debug config is load-bearing.** The Flutter template never defined it for `Runner`
+  (only for `RunnerTests`), so before ISA-40 a `#if DEBUG` block in `AppDelegate.swift`
+  compiled to nothing — silently, in every configuration. **Any Swift `#if DEBUG` in
+  this app depends on that setting**; `$(inherited)` rather than a bare `DEBUG` because
+  the target builds on top of `Flutter/Debug.xcconfig`.
+
 ### Linting
 - Uses `flutter_lints`, `custom_lint`, and `riverpod_lint`
 - Run `flutter analyze` to check for issues

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -697,6 +697,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.isaackwok.moviejournal;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -7,7 +7,33 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    silenceSystemKeyboardConstraintLogs()
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  /// Silences UIKit's "Unable to simultaneously satisfy constraints" console spam.
+  ///
+  /// The only Auto Layout in this process belongs to Apple: TextInputUI (the `TUI*`
+  /// classes) loads into the app and lays out the system keyboard's candidate /
+  /// QuickType bar. It ships with a broken constraint set — a `TUIPredictionViewCell`
+  /// whose width is 0 while its `TUICandidateGradientContentLabel` is pinned 6pt from
+  /// both edges — so every keyboard presentation logs several unsatisfiable-constraint
+  /// blocks (ISA-40: opening the caption editor from a selected scene). Every widget
+  /// this app draws is a Flutter layer, not a `UIView` with constraints, so there is
+  /// nothing on our side to fix and nothing of ours to lose by muting the log.
+  ///
+  /// `_UIConstraintBasedLayoutLogUnsatisfiable` is the flag UIKit itself checks before
+  /// logging. It is read from `NSUserDefaults`, so `NSArgumentDomain` still outranks
+  /// what we write here: pass `-_UIConstraintBasedLayoutLogUnsatisfiable YES` in the
+  /// Xcode scheme's launch arguments to get the logs back while debugging a native
+  /// plugin's own constraints.
+  ///
+  /// Debug-only, so release builds keep stock UIKit diagnostics and the App Store
+  /// binary contains no reference to a private default.
+  private func silenceSystemKeyboardConstraintLogs() {
+    #if DEBUG
+      UserDefaults.standard.set(false, forKey: "_UIConstraintBasedLayoutLogUnsatisfiable")
+    #endif
   }
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {


### PR DESCRIPTION
## What

Opening `CaptionEditor` from a selected scene printed several *"Unable to simultaneously satisfy constraints"* blocks to the console.

## Root cause — it isn't our layout

The classes in the log — `TUIPredictionViewCell`, `TUICandidateGradientContentLabel` — are **TextInputUI**, Apple's framework for the system keyboard's candidate / QuickType bar. It loads *into the app process*, which is why its logs surface in our console. The constraint set it installs is self-contradictory: a prediction cell with `width == 0` whose label is pinned 6pt from both leading and trailing edges.

Nothing in a Flutter widget tree creates or can prevent those. Flutter composites layers; it does not build constrained `UIView`s. `CaptionEditor` merely *triggers* it — `initState` auto-focuses the caption `TextField` via a post-frame callback, so the keyboard opens the instant the screen appears.

## Fix

Set `_UIConstraintBasedLayoutLogUnsatisfiable` to `false` at launch — the flag UIKit itself consults before logging — **in debug builds only**.

Escape hatch: `NSArgumentDomain` outranks what `AppDelegate` writes, so `-_UIConstraintBasedLayoutLogUnsatisfiable YES` in the Xcode scheme's launch arguments restores the logs when debugging a native plugin's own constraints.

## Why the second file changed

`SWIFT_ACTIVE_COMPILATION_CONDITIONS` was defined only on the **RunnerTests** target — the Flutter template never set it for **Runner**. So `#if DEBUG` in `AppDelegate.swift` compiled to nothing in *every* configuration. Without this line the fix above would have been silently inert, and so would any future `#if DEBUG` in this app. `$(inherited)` rather than a bare `DEBUG`, because the target builds on `Flutter/Debug.xcconfig`.

## Rejected alternative

`autocorrect: false` / `enableSuggestions: false` on the caption field. It suppresses the QuickType bar on Latin keyboards only, does nothing for the CJK candidate bar (which is how you type, and matches the `TUICandidate…` classes in the report), and degrades real text input to quiet a developer-only log.

## Cost

Mutes *all* unsatisfiable-constraint logging in debug, including any from native plugin UI (share sheets, sign-in). Acceptable: the app owns no Auto Layout. Documented in `CLAUDE.md` along with the escape hatch.

## Verification

- No Dart, no `pubspec` — the Flutter test suite is untouched by this change (`git diff --name-only` is 3 files: `CLAUDE.md`, `AppDelegate.swift`, `project.pbxproj`).
- `project.pbxproj` checked structurally: brace count unchanged (110/110), exactly one added statement, landing inside the Runner target's `Debug` `XCBuildConfiguration`.
- **Not verified on device** — this agent runtime is Linux, with no Xcode or Swift toolchain, so the Swift change could not be compiled or run here.

**Please confirm on a device:** `flutter run` → journal a movie → select scenes → save → tap a selected scene to open the caption editor. The constraint blocks should be gone from the console.

Closes ISA-40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)