### PR TITLE
chore(deps): sign_in_with_apple 6.1.4→8.1.0, fluttertoast 9.0.0→9.1.0 (ISA-17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ Uses **Riverpod** for state management:
 - **flutter_riverpod** (3.0.3) - State management framework
 - **dio** (5.8.0+1) - HTTP client for API calls
 - **supabase_flutter** (2.16.0) - Auth + Postgres data layer (replaced `cloud_firestore`)
-- **sign_in_with_apple** (6.1.4) - Native Apple credential for `signInWithIdToken`
+- **sign_in_with_apple** (8.1.0) - Native Apple credential for `signInWithIdToken`. 8.x moved the Apple sources to `darwin/sign_in_with_apple/` and added a `Package.swift`, so this plugin builds via SPM rather than the CocoaPods fallback. It is why `pubspec.yaml` now declares `environment.flutter: ">=3.41.0"`. Neither major-version break touches this app: the 8.0.0 `IconAlignment` → `SignInWithAppleIconAlignment` rename only affects `SignInWithAppleButton` (we render `ProviderSignInButton`), and the 7.0.0 `AuthorizationErrorCode` additions (`notInteractive`, `credentialExport`) only break exhaustive switches — `cancellable()` does a single `== canceled` check, so new codes correctly `rethrow`.
 - **firebase_core** (4.10.0) - Firebase initialization
 - **firebase_auth** (6.5.2) - **Transitional.** Only the anonymous-account bridge uses this; not for auth in new code. Removed at the Firestore freeze.
 - **firebase_analytics** (12.4.2) - Google Analytics for Firebase (screen views, custom events, user properties)
@@ -212,12 +212,12 @@ Uses **Riverpod** for state management:
 - **google_fonts** (6.2.1) - Custom typography (e.g., Nothing You Could Do font)
 - **flutter_svg** (2.1.0) - SVG rendering support
 - **jiffy** (6.4.3) - Date formatting and manipulation
-- **fluttertoast** (9.0.0) - Toast notifications
+- **fluttertoast** (9.1.0) - Toast notifications. 9.1.0's entire changelog is "Migrated ios to SPM"; no API change.
 - **uuid** (4.5.1) - Unique ID generation for journal entries
 - **cupertino_icons** (1.0.8) - iOS-style icons
 - **gal** (2.3.0) - Save images/videos to device gallery (used by share ticket feature)
 - **share_plus** (12.0.1) - Native share sheet for sharing files/text (used by share ticket feature)
-- **appinio_social_share** (0.3.2) - Instagram Story sticker sharing via pasteboard/intent (requires Facebook App ID)
+- **appinio_social_share** (0.3.2) - Instagram Story sticker sharing via pasteboard/intent (requires Facebook App ID). **The last non-SPM plugin** and unmaintained (0.3.2 is the latest; no release since 2024-08). Its archive ships only `ios/*.podspec` + `ios/Classes/`, no `Package.swift` — Flutter detects SPM by that exact file layout (`<platform>/<plugin_name>/Package.swift`), not by pub.dev metadata, so the package page's mention of "Swift Package" (which refers to adding the TikTok SDK) is irrelevant. Flutter still falls back to CocoaPods for it, so iOS builds fine; it is the sole reason the "plugins not using SPM" warning persists. Options if that ever matters: own the ~40 lines of Instagram Story code directly (pasteboard + `instagram-stories://` URL scheme), vendor a fork with a `Package.swift`, or wait.
 - **url_launcher** (6.3.1) - Opens URLs externally (used for Threads Web Intent sharing)
 
 ### Dev Dependencies

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -492,10 +492,10 @@ packages:
     dependency: "direct main"
     description:
       name: fluttertoast
-      sha256: "144ddd74d49c865eba47abe31cbc746c7b311c82d6c32e571fd73c4264b740e2"
+      sha256: "7903c9d5339173497bfecbc23bc4212f5a87e0edfac2e1693fb74465ea67da7e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.1.0"
   freezed_annotation:
     dependency: transitive
     description:
@@ -1084,26 +1084,26 @@ packages:
     dependency: "direct main"
     description:
       name: sign_in_with_apple
-      sha256: e84a62e17b7e463abf0a64ce826c2cd1f0b72dff07b7b275e32d5302d76fb4c5
+      sha256: d284f8e235ab0c5be09a1e9146466912bae8f15f0bd5eb3c4cb999b57cd5c3f9
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "8.1.0"
   sign_in_with_apple_platform_interface:
     dependency: transitive
     description:
       name: sign_in_with_apple_platform_interface
-      sha256: c2ef2ce6273fce0c61acd7e9ff5be7181e33d7aa2b66508b39418b786cca2119
+      sha256: "981bca52cf3bb9c3ad7ef44aace2d543e5c468bb713fd8dda4275ff76dfa6659"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "2.0.0"
   sign_in_with_apple_web:
     dependency: transitive
     description:
       name: sign_in_with_apple_web
-      sha256: "2f7c38368f49e3f2043bca4b46a4a61aaae568c140a79aa0675dc59ad0ca49bc"
+      sha256: f316400827f52cafcf50d00e1a2e8a0abc534ca1264e856a81c5f06bd5b10fed
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   skeletonizer:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,10 @@ version: 1.0.0+1
 
 environment:
   sdk: ^3.7.2
+  # Floored by sign_in_with_apple 8.x. Stated explicitly so an older toolchain
+  # fails with "requires Flutter >=3.41.0" instead of an opaque solver error
+  # naming a transitive package.
+  flutter: ">=3.41.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -41,7 +45,9 @@ dependencies:
   flutter_riverpod: ^3.0.3
   skeletonizer: ^2.0.1
   jiffy: ^6.4.3
-  fluttertoast: ^9.0.0
+  # 9.1.0 is "Migrated ios to SPM" and nothing else — floor it so the
+  # SPM-capable build is what resolves.
+  fluttertoast: ^9.1.0
   uuid: ^4.5.1
   firebase_core: ^4.2.0
   # Permanent: Analytics stays on Firebase (plan decision 6).
@@ -55,10 +61,21 @@ dependencies:
   google_sign_in: ^7.2.0
   # Supabase — the data layer as of the Phase 5 call-site swap.
   supabase_flutter: ^2.8.0
-  sign_in_with_apple: ^6.1.3
+  # 8.x is a two-major bump from 6.1.x, taken for SPM support (the plugin's
+  # Apple sources moved to darwin/sign_in_with_apple/Package.swift). Neither
+  # breaking change lands here: 8.0.0 renamed IconAlignment ->
+  # SignInWithAppleIconAlignment, which only affects SignInWithAppleButton
+  # (we render our own ProviderSignInButton), and 7.0.0 added
+  # AuthorizationErrorCode cases, which only breaks exhaustive switches
+  # (cancellable() does a single == check).
+  sign_in_with_apple: ^8.1.0
   crypto: ^3.0.6
   gal: ^2.3.0
   share_plus: ^12.0.1
+  # No SPM support and no release since 2024-08 — 0.3.2 is the latest. Flutter
+  # still falls back to CocoaPods for it, so the iOS build works, but this is
+  # the one plugin keeping the "plugins not using SPM" warning alive. See
+  # ISA-17 for the three exit routes (own the ~40 lines, vendor a fork, wait).
   appinio_social_share: ^0.3.2
   url_launcher: ^6.3.1
 


### PR DESCRIPTION
## What

Upgrades the two of three flagged plugins that now ship a Swift Package Manager manifest, so they build via SPM rather than the CocoaPods fallback.

| Plugin | Was | Now | `Package.swift` in the resolved archive |
| --- | --- | --- | --- |
| `sign_in_with_apple` | 6.1.4 | **8.1.0** | ✅ `darwin/sign_in_with_apple/Package.swift` |
| `fluttertoast` | 9.0.0 | **9.1.0** | ✅ `ios/fluttertoast/Package.swift` |
| `appinio_social_share` | 0.3.2 | 0.3.2 (unchanged) | ❌ only `ios/*.podspec` + `ios/Classes/` |

Verified by inspecting the archives pub actually resolved into `~/.pub-cache`, not the pub.dev descriptions — Flutter detects SPM by the `<platform>/<plugin_name>/Package.swift` file layout.

## Why the two-major `sign_in_with_apple` jump is safe here

Checked each breaking change against the call sites in `lib/supabase_auth_manager.dart`:

- **8.0.0 renamed `IconAlignment` → `SignInWithAppleIconAlignment`.** Only affects `SignInWithAppleButton`. `login.dart` and `SecureAccountSheet` both render the shared `ProviderSignInButton`; the symbol appears nowhere in `lib/` or `test/`.
- **7.0.0 extended `AuthorizationErrorCode`** (adds `notInteractive`, `credentialExport`). Only breaking for an exhaustive `switch`. `cancellable()` (`supabase_auth_manager.dart:333`) does a single `e.code == AuthorizationErrorCode.canceled` equality check, so new codes fall through to `rethrow` — which is the behaviour we want anyway.
- **Everything called is unchanged in 8.1.0**: `SignInWithApple.getAppleIDCredential({scopes, nonce})` has the same signature, `AppleIDAuthorizationScopes.email/.fullName` and `SignInWithAppleAuthorizationException.code` are intact.

## Also in this PR

- **`environment.flutter: ">=3.41.0"` is now declared.** `sign_in_with_apple` 8.x floors it; without the explicit constraint an older toolchain fails with an opaque solver error naming a transitive package instead of stating the requirement.
- `appinio_social_share` gets a comment recording *why* it is pinned (no SPM, no release since 2024-08, 0.3.2 is latest) and the three exit routes.
- CLAUDE.md's Key Dependencies entries updated for all three.

## Lockfile

Exactly 4 packages change, +8/−8 lines — no churn:

```
fluttertoast                        9.0.0 → 9.1.0
sign_in_with_apple                  6.1.4 → 8.1.0
sign_in_with_apple_platform_interface 1.1.0 → 2.0.0
sign_in_with_apple_web              2.1.1 → 3.0.0
```

## Verification

```
flutter analyze   No issues found! (ran in 11.3s)
flutter test      All tests passed!  (421 passed, 7 skipped)
```

## Caveats for the reviewer

- **This does not silence the "plugins not using SPM" warning.** `appinio_social_share` is unmaintained with no SPM and no newer version; Flutter keeps the CocoaPods fallback alive for it, so the iOS build works but the warning stays. Clearing it needs a separate decision (own the Instagram Story code, vendor a patched fork, or wait) — not in this issue's scope.
- **No iOS build was run** — this agent runtime is Linux-only. The Apple sign-in path is verified at the Dart API level (analyze + the API-surface diff above), not on device. The next macOS build will regenerate `ios/Podfile.lock` (dropping the `fluttertoast` and `sign_in_with_apple` pods) and `ios/Runner.xcodeproj/.../swiftpm/Package.resolved` (gaining them); that regeneration should be committed then. **Please smoke-test Sign in with Apple, including cancelling the sheet** (the `cancellable()` path) before merging to a release build.
- Overlaps `pubspec.yaml`/`pubspec.lock` with #39 (ISA-18, `cached_network_image`). Whichever merges second needs a trivial conflict resolution — different lines in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)