### PR TITLE
Hide emotions prompt in read-only journal view

### DIFF
--- a/lib/features/journal/widgets/emotions_selector_button.dart
+++ b/lib/features/journal/widgets/emotions_selector_button.dart
@@ -139,17 +139,19 @@ class EmotionsSelectorButton extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const Text(
-          'What are your feelings about this movie?',
-          style: TextStyle(
-            color: Colors.white,
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
-            fontFamily: 'AvenirNext',
-            height: 1.5,
+        if (!readonly) ...[
+          const Text(
+            'What are your feelings about this movie?',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+              fontFamily: 'AvenirNext',
+              height: 1.5,
+            ),
           ),
-        ),
-        const SizedBox(height: 16),
+          const SizedBox(height: 16),
+        ],
         Material(
           color: Colors.transparent,
           child: InkWell(

--- a/test/features/journal/widgets/emotions_selector_button_test.dart
+++ b/test/features/journal/widgets/emotions_selector_button_test.dart
@@ -190,6 +190,23 @@ void main() {
         expect(find.byIcon(Icons.edit), findsOneWidget);
         expect(find.byIcon(Icons.add), findsNothing);
       });
+
+      testWidgets('hides the prompt when displaying emotions read-only', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(
+            emotions: [emotionList[EmotionType.joyful]!],
+            readonly: true,
+          ),
+        );
+
+        expect(
+          find.text('What are your feelings about this movie?'),
+          findsNothing,
+        );
+        expect(find.textContaining('You felt'), findsOneWidget);
+      });
     });
 
     group('energy-based gradient', () {


### PR DESCRIPTION
### Motivation

- The journal viewing screen should not show the editable prompt "What are your feelings about this movie?"; that prompt belongs only in the create/edit flows and must be hidden when displaying a saved journal in read-only mode.

### Description

- Render the prompt conditionally in `EmotionsSelectorButton` so the text and its spacing are shown only when `readonly` is `false` by wrapping the prompt in `if (!readonly) ...` in `lib/features/journal/widgets/emotions_selector_button.dart`.
- Preserve the existing read-only summary UI (the "You felt … by this movie." sentence) while preventing the prompt from appearing in journal view.
- Add a widget test `hides the prompt when displaying emotions read-only` to `test/features/journal/widgets/emotions_selector_button_test.dart` that asserts the prompt is absent in `readonly: true` mode and the emotion summary still appears.

### Testing

- Ran `git diff --check` with no issues reported on the modified files (style/whitespace check passed). 
- Attempted to run `dart format` on the modified files with `dart format ...` but the Dart SDK was not available in the environment so formatting could not be executed (failure due to missing `dart`).
- Attempted to run the widget test with `flutter test test/features/journal/widgets/emotions_selector_button_test.dart` but the Flutter SDK was not available in the environment so tests could not be executed (failure due to missing `flutter`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79456d4e04832ebb031346122f90d3)